### PR TITLE
Rename project tag setting to environment

### DIFF
--- a/docs/raw/project.md
+++ b/docs/raw/project.md
@@ -13,12 +13,12 @@ name
 
 
 
-tag
-----
+environment
+-----------
 
 - Type: `string` 
 
-// description for tag
+// description for environment
 
 
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -4,7 +4,7 @@ package docs
 
 var docsProject = map[string]string{
 	"name": "",
-	"tag": "",
+	"environment": "",
 	"project_settings": "",
 	"authentication": "",
 	"authorization": "",

--- a/internal/docs/models.go
+++ b/internal/docs/models.go
@@ -104,6 +104,9 @@ func InjectModels() {
 
 func inject(model map[string]schema.Attribute, docs map[string]string) {
 	for field, desc := range docs {
+		if _, found := model[field]; !found {
+			panic(fmt.Sprintf("missing schema attribute for documentation key %s", field))
+		}
 		switch attr := model[field].(type) {
 		case schema.StringAttribute:
 			attr.MarkdownDescription = desc

--- a/internal/models/connectors/shared.go
+++ b/internal/models/connectors/shared.go
@@ -157,6 +157,7 @@ type HTTPAuthFieldModel struct {
 
 func (m *HTTPAuthFieldModel) Values(h *helpers.Handler) map[string]any {
 	data := map[string]any{}
+	data["method"] = "none"
 	if v := m.BearerToken.ValueString(); v != "" {
 		data["method"] = "bearerToken"
 		data["bearerToken"] = v

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -24,7 +24,7 @@ import (
 var ProjectAttributes = map[string]schema.Attribute{
 	"id":               stringattr.Identifier(),
 	"name":             stringattr.Required(),
-	"tag":              stringattr.Optional(stringvalidator.OneOf("production")),
+	"environment":      stringattr.Optional(stringvalidator.OneOf("production")),
 	"project_settings": objectattr.Optional(settings.SettingsAttributes),
 	"authentication":   objectattr.Optional(authentication.AuthenticationAttributes),
 	"authorization":    objectattr.Optional(authorization.AuthorizationAttributes, authorization.AuthorizationValidator),
@@ -39,7 +39,7 @@ var ProjectAttributes = map[string]schema.Attribute{
 type ProjectModel struct {
 	ID             types.String                        `tfsdk:"id"`
 	Name           types.String                        `tfsdk:"name"`
-	Tag            types.String                        `tfsdk:"tag"`
+	Environment    types.String                        `tfsdk:"environment"`
 	Settings       *settings.SettingsModel             `tfsdk:"project_settings"`
 	Authentication *authentication.AuthenticationModel `tfsdk:"authentication"`
 	Authorization  *authorization.AuthorizationModel   `tfsdk:"authorization"`
@@ -55,7 +55,7 @@ func (m *ProjectModel) Values(h *helpers.Handler) map[string]any {
 	data := map[string]any{}
 	data["version"] = ModelVersion
 	stringattr.Get(m.Name, data, "name")
-	stringattr.Get(m.Tag, data, "tag")
+	stringattr.Get(m.Environment, data, "environment")
 	objectattr.Get(m.Settings, data, "settings", h)
 	objectattr.Get(m.Authentication, data, "authentication", h)
 	objectattr.Get(m.Connectors, data, "connectors", h)
@@ -74,7 +74,7 @@ func (m *ProjectModel) SetValues(h *helpers.Handler, data map[string]any) {
 	}
 
 	stringattr.Set(&m.Name, data, "name")
-	stringattr.Set(&m.Tag, data, "tag")
+	stringattr.Set(&m.Environment, data, "environment")
 	objectattr.Set(&m.Settings, data, "settings", h)
 	objectattr.Set(&m.Authentication, data, "authentication", h)
 	objectattr.Set(&m.Connectors, data, "connectors", h)

--- a/internal/models/project_test.go
+++ b/internal/models/project_test.go
@@ -13,18 +13,18 @@ func TestProject(t *testing.T) {
 	testacc.Run(t,
 		resource.TestStep{
 			Config: p.Config(`
-				tag = "foo"
+				environment = "foo"
 			`),
 			ExpectError: regexp.MustCompile(`Invalid Attribute Value`),
 		},
 		resource.TestStep{
 			Config: p.Config(`
-				tag = "production"
+				environment = "production"
 			`),
 			Check: p.Check(map[string]any{
-				"id":   testacc.AttributeIsSet,
-				"tag":  "production",
-				"name": p.Name,
+				"id":          testacc.AttributeIsSet,
+				"environment": "production",
+				"name":        p.Name,
 			}),
 		},
 		resource.TestStep{

--- a/tools/terragen/srcgen/models.gotmpl
+++ b/tools/terragen/srcgen/models.gotmpl
@@ -22,6 +22,9 @@ func InjectModels() {
 
 func inject(model map[string]schema.Attribute, docs map[string]string) {
 	for field, desc := range docs {
+		if _, found := model[field]; !found {
+			panic(fmt.Sprintf("missing schema attribute for documentation key %s", field))
+		}
 		switch attr := model[field].(type) {
 		case schema.StringAttribute:
 			attr.MarkdownDescription = desc


### PR DESCRIPTION
## Description
- Rename project `tag` setting to `environment`
- Send HTTP authentication method `none`
- Add check for missing attributes for documentation tags

## Must
- [X] Tests
- [X] Documentation (if applicable)
