### PR TITLE
Rename domain attribute to cookie_domain

### DIFF
--- a/docs/raw/settings/settings.md
+++ b/docs/raw/settings/settings.md
@@ -4,16 +4,6 @@ Settings
 
 
 
-domain
-------
-
-- Type: `string` 
-
-The Domain name for custom domain set up. To read more about custom domain and
-cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
-
-
-
 approved_domains
 ----------------
 
@@ -42,6 +32,16 @@ cookie_policy
 
 Use "strict", "lax" or "none". To read more about custom domain and cookie policy
 click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+
+
+
+cookie_domain
+-------------
+
+- Type: `string` 
+
+The domain name for custom domain set up. To read more about custom domain and
+cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 
 
 
@@ -149,3 +149,12 @@ access_key_jwt_template
 - Type: `string` 
 
 Name of the access key JWT Template.
+
+
+
+domain
+------
+
+- Type: `string` 
+
+This attribute has been renamed to `cookie_domain`.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1771,8 +1771,9 @@ Optional:
 - `access_key_jwt_template` (String) Name of the access key JWT Template.
 - `access_key_session_token_expiration` (String) The expiry time for access key session tokens. Use values such as "10 minutes", "4 hours", etc. The value needs to be at least 3 minutes and can't be longer than 4 weeks.
 - `approved_domains` (List of String) The list of approved domains that are allowed for redirect and verification URLs for different authentication methods.
+- `cookie_domain` (String) The domain name for custom domain set up. To read more about custom domain and cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 - `cookie_policy` (String) Use "strict", "lax" or "none". To read more about custom domain and cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
-- `domain` (String) The Domain name for custom domain set up. To read more about custom domain and cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+- `domain` (String, Deprecated) This attribute has been renamed to `cookie_domain`.
 - `enable_inactivity` (Boolean) Use `True` to enable session inactivity. To read more about session inactivity click [here](https://docs.descope.com/project-settings#session-inactivity).
 - `inactivity_time` (String) The session inactivity time. Use values such as "15 minutes", "1 hour", etc. The minimum value is "10 minutes".
 - `refresh_token_expiration` (String) The expiry time for the refresh token, after which the user must log in again. Use values such as "4 weeks", "14 days", etc. The minimum value is "3 minutes".

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -676,14 +676,14 @@ var docsJWTTemplates = map[string]string{
 }
 
 var docsSettings = map[string]string{
-	"domain": "The Domain name for custom domain set up. To read more about custom domain and " +
-	          "cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
 	"approved_domains": "The list of approved domains that are allowed for redirect and verification URLs " +
 	                    "for different authentication methods.",
 	"token_response_method": "Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` " +
 	                         "or `cookies`. The default value is `response_body`.",
 	"cookie_policy": "Use \"strict\", \"lax\" or \"none\". To read more about custom domain and cookie policy " +
 	                 "click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
+	"cookie_domain": "The domain name for custom domain set up. To read more about custom domain and " +
+	                 "cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
 	"refresh_token_rotation": "Every time the user refreshes their session token via their refresh token, the " +
 	                          "refresh token itself is also updated to a new one.",
 	"refresh_token_expiration": "The expiry time for the refresh token, after which the user must log in again. Use values " +
@@ -703,6 +703,7 @@ var docsSettings = map[string]string{
 	                             "automatically be marked as a test user.",
 	"user_jwt_template": "Name of the user JWT Template.",
 	"access_key_jwt_template": "Name of the access key JWT Template.",
+	"domain": "This attribute has been renamed to `cookie_domain`.",
 }
 
 var docsEmailService = map[string]string{

--- a/internal/models/helpers/stringattr/string.go
+++ b/internal/models/helpers/stringattr/string.go
@@ -65,6 +65,21 @@ func Default(value string, validators ...validator.String) schema.StringAttribut
 	}
 }
 
+func Deprecated(message string, validators ...validator.String) schema.StringAttribute {
+	return schema.StringAttribute{
+		Optional:           true,
+		Computed:           true,
+		DeprecationMessage: message + " This attribute will be removed in the next major version of the provider.",
+		Validators:         validators,
+		PlanModifiers:      []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+		Default:            NullDefault(),
+	}
+}
+
+func Renamed(oldname, newname string, validators ...validator.String) schema.StringAttribute {
+	return Deprecated("The "+oldname+" attribute has been renamed, set the "+newname+" attribute instead.", validators...)
+}
+
 func Get(s types.String, data map[string]any, key string) {
 	if !s.IsNull() && !s.IsUnknown() {
 		data[key] = s.ValueString()

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -25,7 +25,7 @@ var ProjectAttributes = map[string]schema.Attribute{
 	"id":               stringattr.Identifier(),
 	"name":             stringattr.Required(),
 	"environment":      stringattr.Optional(stringvalidator.OneOf("", "production")),
-	"project_settings": objectattr.Optional(settings.SettingsAttributes),
+	"project_settings": objectattr.Optional(settings.SettingsAttributes, settings.SettingsValidator),
 	"authentication":   objectattr.Optional(authentication.AuthenticationAttributes),
 	"authorization":    objectattr.Optional(authorization.AuthorizationAttributes, authorization.AuthorizationValidator),
 	"attributes":       objectattr.Optional(attributes.AttributesAttributes),

--- a/internal/models/settings/settings_test.go
+++ b/internal/models/settings/settings_test.go
@@ -225,18 +225,47 @@ func TestSettings(t *testing.T) {
 		resource.TestStep{
 			Config: p.Config(`
 				project_settings = {
+					domain = "example1.com"
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"project_settings.domain": "example1.com",
+			}),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				project_settings = {
+					cookie_domain = "example2.com"
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"project_settings.cookie_domain": "example2.com",
+			}),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				project_settings = {
 					domain = "example.com"
+					cookie_domain = "example.com"
+				}
+			`),
+			ExpectError: regexp.MustCompile(`Conflicting Attributes`),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				project_settings = {
 					enable_inactivity = true
 					inactivity_time = "1 hour"
 					cookie_policy = "lax"
+					cookie_domain = "example.com"
 				}
 			`),
 			Check: p.Check(map[string]any{
 				"project_settings.refresh_token_expiration": "4 weeks",
-				"project_settings.domain":                   "example.com",
 				"project_settings.enable_inactivity":        true,
 				"project_settings.inactivity_time":          "1 hour",
 				"project_settings.cookie_policy":            "lax",
+				"project_settings.cookie_domain":            "example.com",
 			}),
 		},
 	)


### PR DESCRIPTION
## Description
- Rename `domain` attribute to `cookie_domain`
- This is partially to keep both relevant attributes "close" together (`cookie_policy` and `cookie_domain`), and partially to test how complicated it is to deprecate an attribute while preserving backwards compatibility (answer: "quite complicated unless I'm missing something").

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
