### PR TITLE
Fix helper calls to not use dynamic string values in format strings

### DIFF
--- a/internal/models/applications/shared.go
+++ b/internal/models/applications/shared.go
@@ -22,14 +22,14 @@ func sharedApplicationData(_ *Handler, id, name, description, logo types.String,
 
 func RequireID(h *Handler, data map[string]any, key string, name types.String, id *types.String) {
 	n := name.ValueString()
-	h.Log("Looking for " + key + " application named '" + n + "'")
+	h.Log("Looking for %s application named '%s'", key, n)
 	if appID, ok := requireID(h, data, key, n); ok {
 		value := types.StringValue(appID)
 		if !(*id).Equal(value) {
-			h.Log("Setting new ID '" + appID + "' for " + key + " application named '" + n + "'")
+			h.Log("Setting new ID '%s' for %s application named '%s'", appID, key, n)
 			*id = value
 		} else {
-			h.Log("Keeping existing ID '" + appID + "' for " + key + " application named '" + n + "'")
+			h.Log("Keeping existing ID '%s' for %s application named '%s'", appID, key, n)
 		}
 	}
 }
@@ -37,7 +37,7 @@ func RequireID(h *Handler, data map[string]any, key string, name types.String, i
 func requireID(h *Handler, data map[string]any, key string, name string) (string, bool) {
 	list, ok := data[key].([]any)
 	if !ok {
-		h.Error("Unexpected server response", "Expected to find list of '"+key+"' applications to match with '"+name+"' application")
+		h.Error("Unexpected server response", "Expected to find list of '%s' applications to match with '%s' application", key, name)
 		return "", false
 	}
 
@@ -51,6 +51,6 @@ func requireID(h *Handler, data map[string]any, key string, name string) (string
 		}
 	}
 
-	h.Error("Application not found", "Expected to find application of type '"+key+"' to match with '"+name+"' application")
+	h.Error("Application not found", "Expected to find application of type '%s' to match with '%s' application", key, name)
 	return "", false
 }

--- a/internal/models/authorization/authorization.go
+++ b/internal/models/authorization/authorization.go
@@ -38,13 +38,13 @@ func (m *AuthorizationModel) SetValues(h *helpers.Handler, data map[string]any) 
 		if found {
 			value := types.StringValue(id)
 			if !role.ID.Equal(value) {
-				h.Log("Setting new ID '" + id + "' for role named '" + name + "'")
+				h.Log("Setting new ID '%s' for role named '%s'", id, name)
 				role.ID = value
 			} else {
-				h.Log("Keeping existing ID '" + id + "' for role named '" + name + "'")
+				h.Log("Keeping existing ID '%s' for role named '%s'", id, name)
 			}
 		} else {
-			h.Error("Role not found", "Expected to find role to match with '"+name+"'")
+			h.Error("Role not found", "Expected to find role to match with '%s'", name)
 		}
 	}
 
@@ -54,13 +54,13 @@ func (m *AuthorizationModel) SetValues(h *helpers.Handler, data map[string]any) 
 		if found {
 			value := types.StringValue(id)
 			if !permission.ID.Equal(value) {
-				h.Log("Setting new ID '" + id + "' for permission named '" + name + "'")
+				h.Log("Setting new ID '%s' for permission named '%s'", id, name)
 				permission.ID = value
 			} else {
-				h.Log("Keeping existing ID '" + id + "' for permission named '" + name + "'")
+				h.Log("Keeping existing ID '%s' for permission named '%s'", id, name)
 			}
 		} else {
-			h.Error("Permission not found", "Expected to find permission to match with '"+name+"'")
+			h.Error("Permission not found", "Expected to find permission to match with '%s'", name)
 		}
 	}
 }

--- a/internal/models/authorization/role.go
+++ b/internal/models/authorization/role.go
@@ -36,7 +36,7 @@ func (m *RoleModel) Values(h *helpers.Handler) map[string]any {
 		h.Log("Updating reference for role '%s' to: %s", roleName, refValue)
 		data["id"] = refValue
 	} else {
-		h.Error("Unknown role reference", "No role named '"+roleName+"' was defined")
+		h.Error("Unknown role reference", "No role named '%s' was defined", roleName)
 		data["id"] = m.ID.ValueString()
 	}
 

--- a/internal/models/connectors/shared.go
+++ b/internal/models/connectors/shared.go
@@ -24,7 +24,7 @@ func connectorValues(id, name, description types.String, h *helpers.Handler) map
 		h.Log("Updating reference for connector '%s' to: %s", connectorName, refValue)
 		data["id"] = refValue
 	} else {
-		h.Error("Unknown connector reference", "No connector named '"+connectorName+"' was defined")
+		h.Error("Unknown connector reference", "No connector named '%s' was defined", connectorName)
 		data["id"] = id.ValueString()
 	}
 
@@ -36,14 +36,14 @@ func connectorValues(id, name, description types.String, h *helpers.Handler) map
 func SetConnectorIDs[T any, M helpers.MatchableModel[T]](h *helpers.Handler, data map[string]any, key string, connectors []M) {
 	for _, connector := range connectors {
 		n := connector.GetName().ValueString()
-		h.Log("Looking for " + key + " connector named '" + n + "'")
+		h.Log("Looking for %s connector named '%s'", key, n)
 		if connectorID, ok := findConnectorID(h, data, key, n); ok {
 			value := types.StringValue(connectorID)
 			if !connector.GetID().Equal(value) {
-				h.Log("Setting new ID '" + connectorID + "' for " + key + " connector named '" + n + "'")
+				h.Log("Setting new ID '%s' for %s connector named '%s'", connectorID, key, n)
 				connector.SetID(value)
 			} else {
-				h.Log("Keeping existing ID '" + connectorID + "' for " + key + " connector named '" + n + "'")
+				h.Log("Keeping existing ID '%s' for %s connector named '%s'", connectorID, key, n)
 			}
 		}
 
@@ -73,7 +73,7 @@ func findConnectorID(h *helpers.Handler, data map[string]any, key string, name s
 		}
 	}
 
-	h.Error("Connector not found", "Expected to find connector of type '"+key+"' to match with '"+name+"' connector")
+	h.Error("Connector not found", "Expected to find connector of type '%s' to match with '%s' connector", key, name)
 	return "", false
 }
 

--- a/internal/models/templates/emailservice.go
+++ b/internal/models/templates/emailservice.go
@@ -28,7 +28,7 @@ func (m *EmailServiceModel) Values(h *helpers.Handler) map[string]any {
 		h.Log("Setting emailServiceProvider reference to connector '%s'", connector)
 		data["emailServiceProvider"] = ref.ProviderValue()
 	} else {
-		h.Error("Unknown connector reference", "No connector named '"+connector+"' for email service was defined")
+		h.Error("Unknown connector reference", "No connector named '%s' for email service was defined", connector)
 	}
 	listattr.Get(m.Templates, data, "emailTemplates", h)
 	return data
@@ -37,14 +37,14 @@ func (m *EmailServiceModel) Values(h *helpers.Handler) map[string]any {
 func (m *EmailServiceModel) SetValues(h *helpers.Handler, data map[string]any) {
 	for _, template := range m.Templates {
 		name := template.Name.ValueString()
-		h.Log("Looking for email template named '" + name + "'")
+		h.Log("Looking for email template named '%s'", name)
 		if id, ok := requireTemplateID(h, data, "emailTemplates", name); ok {
 			value := types.StringValue(id)
 			if !template.ID.Equal(value) {
-				h.Log("Setting new ID '" + id + "' for email template named '" + name + "'")
+				h.Log("Setting new ID '%s' for email template named '%s'", id, name)
 				template.ID = value
 			} else {
-				h.Log("Keeping existing ID '" + id + "' for email template named '" + name + "'")
+				h.Log("Keeping existing ID '%s' for email template named '%s'", id, name)
 			}
 		}
 	}

--- a/internal/models/templates/shared.go
+++ b/internal/models/templates/shared.go
@@ -7,7 +7,7 @@ import (
 func requireTemplateID(h *helpers.Handler, data map[string]any, typ string, name string) (string, bool) {
 	list, ok := data[typ].([]any)
 	if !ok {
-		h.Error("Unexpected server response", "Expected to find list of templates in '"+typ+"' to match with '"+name+"' template")
+		h.Error("Unexpected server response", "Expected to find list of templates in '%s' to match with '%s' template", typ, name)
 		return "", false
 	}
 
@@ -21,6 +21,6 @@ func requireTemplateID(h *helpers.Handler, data map[string]any, typ string, name
 		}
 	}
 
-	h.Error("Template not found", "Expected to find template in '"+typ+"' to match with '"+name+"' template")
+	h.Error("Template not found", "Expected to find template in '%s' to match with '%s' template", typ, name)
 	return "", false
 }

--- a/internal/models/templates/textservice.go
+++ b/internal/models/templates/textservice.go
@@ -28,7 +28,7 @@ func (m *TextServiceModel) Values(h *helpers.Handler) map[string]any {
 		h.Log("Setting textServiceProvider reference to connector '%s'", connector)
 		data["textServiceProvider"] = ref.ProviderValue()
 	} else {
-		h.Error("Unknown connector reference", "No connector named '"+connector+"' for text service was defined")
+		h.Error("Unknown connector reference", "No connector named '%s' for text service was defined", connector)
 	}
 	listattr.Get(m.Templates, data, "textTemplates", h)
 	return data
@@ -37,14 +37,14 @@ func (m *TextServiceModel) Values(h *helpers.Handler) map[string]any {
 func (m *TextServiceModel) SetValues(h *helpers.Handler, data map[string]any) {
 	for _, template := range m.Templates {
 		name := template.Name.ValueString()
-		h.Log("Looking for text template named '" + name + "'")
+		h.Log("Looking for text template named '%s'", name)
 		if id, ok := requireTemplateID(h, data, "textTemplates", name); ok {
 			value := types.StringValue(id)
 			if !template.ID.Equal(value) {
-				h.Log("Setting new ID '" + id + "' for text template named '" + name + "'")
+				h.Log("Setting new ID '%s' for text template named '%s'", id, name)
 				template.ID = value
 			} else {
-				h.Log("Keeping existing ID '" + id + "' for text template named '" + name + "'")
+				h.Log("Keeping existing ID '%s' for text template named '%s'", id, name)
 			}
 		}
 	}

--- a/internal/models/templates/voiceservice.go
+++ b/internal/models/templates/voiceservice.go
@@ -28,7 +28,7 @@ func (m *VoiceServiceModel) Values(h *helpers.Handler) map[string]any {
 		h.Log("Setting voiceServiceProvider reference to connector '%s'", connector)
 		data["voiceServiceProvider"] = ref.ProviderValue()
 	} else {
-		h.Error("Unknown connector reference", "No connector named '"+connector+"' for voice service was defined")
+		h.Error("Unknown connector reference", "No connector named '%s' for voice service was defined", connector)
 	}
 	listattr.Get(m.Templates, data, "voiceTemplates", h)
 	return data
@@ -37,14 +37,14 @@ func (m *VoiceServiceModel) Values(h *helpers.Handler) map[string]any {
 func (m *VoiceServiceModel) SetValues(h *helpers.Handler, data map[string]any) {
 	for _, template := range m.Templates {
 		name := template.Name.ValueString()
-		h.Log("Looking for voice template named '" + name + "'")
+		h.Log("Looking for voice template named '%s'", name)
 		if id, ok := requireTemplateID(h, data, "voiceTemplates", name); ok {
 			value := types.StringValue(id)
 			if !template.ID.Equal(value) {
-				h.Log("Setting new ID '" + id + "' for voice template named '" + name + "'")
+				h.Log("Setting new ID '%s' for voice template named '%s'", id, name)
 				template.ID = value
 			} else {
-				h.Log("Keeping existing ID '" + id + "' for voice template named '" + name + "'")
+				h.Log("Keeping existing ID '%s' for voice template named '%s'", id, name)
 			}
 		}
 	}


### PR DESCRIPTION
## Description
- Prevent silly error if user values contain format modifiers such as `%s` et al

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
