### PR TITLE
Split OAuth validation to two phases

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -31,7 +31,7 @@ description: |-
 - `jwt_templates` (Attributes) Defines templates for JSON Web Tokens (JWT) used for authentication. (see [below for nested schema](#nestedatt--jwt_templates))
 - `project_settings` (Attributes) General settings for the Descope project. (see [below for nested schema](#nestedatt--project_settings))
 - `styles` (Attributes) Custom styles that can be applied to the project's authentication flows. (see [below for nested schema](#nestedatt--styles))
-- `tags` (List of String) Descriptive tags for your Descope project. Tags can contain any character but must be no more than 50 characters long.
+- `tags` (List of String) Descriptive tags for your Descope project. Each tag must be no more than 50 characters long.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,10 @@ require (
 	github.com/stretchr/testify v1.10.0
 )
 
-require github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-
 require (
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect

--- a/internal/resources/project.go
+++ b/internal/resources/project.go
@@ -49,11 +49,6 @@ func (r *projectResource) ValidateConfig(ctx context.Context, req resource.Valid
 		return
 	}
 
-	_ = entity.Values(ctx)
-	if entity.Diagnostics.HasError() {
-		return
-	}
-
 	tflog.Info(ctx, "Project resource validated")
 }
 

--- a/tools/terragen/conngen/connector.go
+++ b/tools/terragen/conngen/connector.go
@@ -89,16 +89,16 @@ func (c *Connector) HasValidator() bool {
 			}
 			// a few sanity checks to make sure we support what's expected
 			if f.Required {
-				log.Fatalf("Unexpected required field with dependency " + f.Name)
+				log.Fatalf("Unexpected required field with dependency %s", f.Name)
 			}
 			if f.Dependency.Field == nil {
-				log.Fatalf("Failed to find matching field for dependency " + f.Dependency.Name + " in connector " + c.ID)
+				log.Fatalf("Failed to find matching field for dependency %s in connector %s", f.Dependency.Name, c.ID)
 			}
 			if f.Dependency.Field.Type != FieldTypeBool {
-				log.Fatalf("Field " + f.Name + " has a dependency on " + f.Dependency.Field.Name + " whose type is not a boolean (other types are not currently supported)")
+				log.Fatalf("Field %s has a dependency on %s whose type is not a boolean (other types are not currently supported)", f.Name, f.Dependency.Field.Name)
 			}
 			if f.Dependency.Value != true {
-				log.Fatalf("Field " + f.Name + " has a dependency whose value is not true (other values are not currently supported)")
+				log.Fatalf("Field %s has a dependency whose value is not true (other values are not currently supported)", f.Name)
 			}
 		}
 	}


### PR DESCRIPTION
## Description
- Split OAuth validation to two phases.
- As a result of the above some complex validation rules are only enforced during `terraform apply`.

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
