### PR TITLE
Fix warning about mismatched values in string lists

### DIFF
--- a/internal/models/applications/oidc.go
+++ b/internal/models/applications/oidc.go
@@ -37,7 +37,7 @@ func (m *OIDCModel) Values(h *Handler) map[string]any {
 	data := sharedApplicationData(h, m.ID, m.Name, m.Description, m.Logo, m.Disabled)
 	settings := map[string]any{}
 	stringattr.Get(m.LoginPageURL, settings, "loginPageUrl")
-	strlistattr.Get(m.Claims, settings, "claims")
+	strlistattr.Get(m.Claims, settings, "claims", h)
 	boolattr.Get(m.ForceAuthentication, settings, "forceAuthentication")
 	data["oidc"] = settings
 	return data

--- a/internal/models/applications/saml.go
+++ b/internal/models/applications/saml.go
@@ -65,7 +65,7 @@ func (m *SAMLModel) Values(h *Handler) map[string]any {
 	stringattr.Get(m.SubjectNameIDFormat, settings, "subjectNameIdFormat")
 	stringattr.Get(m.DefaultRelayState, settings, "defaultRelayState")
 	listattr.Get(m.AttributeMapping, settings, "attributeMapping", h)
-	strlistattr.Get(m.ACSAllowedCallbackURLs, settings, "acsAllowedCallbacks")
+	strlistattr.Get(m.ACSAllowedCallbackURLs, settings, "acsAllowedCallbacks", h)
 	boolattr.Get(m.ForceAuthentication, settings, "forceAuthentication")
 	data["saml"] = settings
 	return data

--- a/internal/models/authentication/oauth.go
+++ b/internal/models/authentication/oauth.go
@@ -298,16 +298,16 @@ func (m *OAuthProviderModel) Values(h *helpers.Handler) map[string]any {
 		data["manageProviderTokens"] = false
 	}
 	if len(m.Prompts) > 0 {
-		strlistattr.Get(m.Prompts, data, "prompts")
+		strlistattr.Get(m.Prompts, data, "prompts", h)
 	}
 	if len(m.Scopes) > 0 {
-		strlistattr.Get(m.Scopes, data, "scopes")
+		strlistattr.Get(m.Scopes, data, "scopes", h)
 	}
 	boolattr.Get(m.MergeUserAccounts, data, "trustProvidedEmails")
 	stringattr.Get(m.Description, data, "description")
 	stringattr.Get(m.Logo, data, "logo")
 	if len(m.AllowedGrantTypes) > 0 {
-		strlistattr.Get(m.AllowedGrantTypes, data, "allowedGrantTypes")
+		strlistattr.Get(m.AllowedGrantTypes, data, "allowedGrantTypes", h)
 	}
 	stringattr.Get(m.Issuer, data, "issuer")
 	stringattr.Get(m.AuthorizationEndpoint, data, "authUrl")

--- a/internal/models/authorization/role.go
+++ b/internal/models/authorization/role.go
@@ -27,7 +27,7 @@ func (m *RoleModel) Values(h *helpers.Handler) map[string]any {
 	data := map[string]any{}
 	stringattr.Get(m.Name, data, "name")
 	stringattr.Get(m.Description, data, "description")
-	strlistattr.Get(m.Permissions, data, "permissions")
+	strlistattr.Get(m.Permissions, data, "permissions", h)
 
 	// use the name as a lookup key to set the role reference or existing id
 	roleName := m.Name.ValueString()

--- a/internal/models/connectors/shared.go
+++ b/internal/models/connectors/shared.go
@@ -160,14 +160,14 @@ func (m *AuditFilterFieldModel) Values(h *helpers.Handler) map[string]any {
 	data := map[string]any{}
 	stringattr.Get(m.Key, data, "key")
 	stringattr.Get(m.Operator, data, "operator")
-	strlistattr.Get(m.Vals, data, "values")
+	strlistattr.Get(m.Vals, data, "values", h)
 	return data
 }
 
 func (m *AuditFilterFieldModel) SetValues(h *helpers.Handler, data map[string]any) {
 	stringattr.Set(&m.Key, data, "key")
 	stringattr.Set(&m.Operator, data, "operator")
-	strlistattr.Set(&m.Vals, data, "values")
+	strlistattr.Set(&m.Vals, data, "values", h)
 }
 
 // HTTP Headers

--- a/internal/models/helpers/handler.go
+++ b/internal/models/helpers/handler.go
@@ -31,6 +31,10 @@ func (h *Handler) Warn(summary string, format string, a ...any) {
 	h.Diagnostics.AddWarning(summary, fmt.Sprintf(format, a...))
 }
 
+func (h *Handler) Mismatch(format string, a ...any) {
+	h.Diagnostics.AddWarning("Attribute Value Mismatch", fmt.Sprintf(format, a...))
+}
+
 func (h *Handler) Error(summary string, format string, a ...any) {
 	h.Diagnostics.AddError(summary, fmt.Sprintf(format, a...))
 }

--- a/internal/models/helpers/helpers.go
+++ b/internal/models/helpers/helpers.go
@@ -1,5 +1,7 @@
 package helpers
 
+import "slices"
+
 func AnySliceToStringSlice(data map[string]any, key string) []string {
 	var strs []string
 	if objects, ok := data[key].([]any); ok {
@@ -10,4 +12,16 @@ func AnySliceToStringSlice(data map[string]any, key string) []string {
 		}
 	}
 	return strs
+}
+
+func EqualStringSliceElements(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, v := range a {
+		if !slices.Contains(b, v) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/models/helpers/strlistattr/strlist.go
+++ b/internal/models/helpers/strlistattr/strlist.go
@@ -1,9 +1,9 @@
 package strlistattr
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -28,23 +28,19 @@ func Optional(validators ...validator.List) schema.ListAttribute {
 	}
 }
 
-func Get(s []string, data map[string]any, key string) {
+func Get(s []string, data map[string]any, key string, _ *helpers.Handler) {
 	data[key] = s
 }
 
-func Set(s *[]string, data map[string]any, key string) {
-	if v, ok := data[key].([]any); ok {
-		*s = []string{}
-		if len(v) > 0 {
-			for i := range v {
-				str, ok := v[i].(string)
-				if !ok {
-					panic(fmt.Sprintf("unexpected value of type %T in string list: %s", v[i], key))
-				}
-				*s = append(*s, str)
-			}
+func Set(s *[]string, data map[string]any, key string, h *helpers.Handler) {
+	values := helpers.AnySliceToStringSlice(data, key)
+	if len(*s) > 0 {
+		if !helpers.EqualStringSliceElements(*s, values) {
+			h.Mismatch("Mismatched string array value in '%s' key: received [%s], expected [%s]", key, strings.Join(values, ","), strings.Join(*s, ","))
 		}
+		return
 	}
+	*s = values
 }
 
 func GetCommaSeparated(s []string, data map[string]any, key string) {

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -62,7 +62,7 @@ func (m *ProjectModel) Values(h *helpers.Handler) map[string]any {
 	data["version"] = ModelVersion
 	stringattr.Get(m.Name, data, "name")
 	stringattr.Get(m.Environment, data, "environment")
-	strlistattr.Get(m.Tags, data, "tags")
+	strlistattr.Get(m.Tags, data, "tags", h)
 	objectattr.Get(m.Settings, data, "settings", h)
 	objectattr.Get(m.Invite, data, "settings", h)
 	objectattr.Get(m.Authentication, data, "authentication", h)
@@ -83,7 +83,7 @@ func (m *ProjectModel) SetValues(h *helpers.Handler, data map[string]any) {
 
 	stringattr.Set(&m.Name, data, "name")
 	stringattr.Set(&m.Environment, data, "environment")
-	strlistattr.Set(&m.Tags, data, "tags")
+	strlistattr.Set(&m.Tags, data, "tags", h)
 	objectattr.Set(&m.Settings, data, "settings", h)
 	objectattr.Set(&m.Invite, data, "settings", h)
 	objectattr.Set(&m.Authentication, data, "authentication", h)


### PR DESCRIPTION

## Description
- Fix warning about mismatched values when string lists have the same elements in a different order

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
