### PR TITLE
Upgrade to Go 1.24

### DIFF
--- a/.github/actions/ci/lint/action.yml
+++ b/.github/actions/ci/lint/action.yml
@@ -9,7 +9,7 @@ runs:
       uses: ./.github/actions/ci/setup
 
     - name: Run Linter
-      uses: golangci/golangci-lint-action@2e788936b09dd82dc280e845628a40d2ba6b204c # v6.3.1
+      uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
       with:
-        version: v1.60.3
+        version: v1.64.5
         args: --config=.github/actions/ci/lint/golangci.yml

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/descope/terraform-provider-descope
 
-go 1.22.7
+go 1.24
 
-toolchain go1.22.10
+toolchain go1.24.0
 
 require (
 	github.com/descope/go-sdk v1.6.9


### PR DESCRIPTION
## Description
- Upgrade to Go 1.24

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
