### PR TITLE
Add support for static OTP for test users

### DIFF
--- a/internal/models/helpers/stringattr/validators.go
+++ b/internal/models/helpers/stringattr/validators.go
@@ -16,6 +16,8 @@ var StandardLenValidator = stringvalidator.LengthAtMost(254)
 
 var FlowIDValidator = stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z0-9_-]+$`), "must only contain alphanumeric, underscore or hyphen characters")
 
+var OTPValidator = stringvalidator.RegexMatches(regexp.MustCompile(`^[0-9]{6}$`), "must be a 6 digit code")
+
 var NonEmptyValidator validator.String = &nonEmptyValidator{}
 
 // Non-Empty

--- a/internal/models/project/project.go
+++ b/internal/models/project/project.go
@@ -58,6 +58,7 @@ type ProjectModel struct {
 }
 
 func (m *ProjectModel) Values(h *helpers.Handler) map[string]any {
+	m.Check(h)
 	data := map[string]any{}
 	data["version"] = helpers.ModelVersion
 	stringattr.Get(m.Name, data, "name")
@@ -94,6 +95,16 @@ func (m *ProjectModel) SetValues(h *helpers.Handler, data map[string]any) {
 	objectattr.Set(&m.JWTTemplates, data, "jwtTemplates", h)
 	objectattr.Set(&m.Styles, data, "styles", h)
 	mapattr.Set(&m.Flows, data, "flows", h)
+}
+
+func (m *ProjectModel) Check(h *helpers.Handler) {
+	if m.Environment.ValueString() == "production" {
+		if v := m.Settings; v != nil {
+			if v.TestUsersStaticOTP.ValueString() != "" {
+				h.Error("Invalid Production Settings", "The test_users_static_otp attribute cannot be used with production projects")
+			}
+		}
+	}
 }
 
 func (m *ProjectModel) References(ctx context.Context) helpers.ReferencesMap {

--- a/internal/models/project/settings/settings.go
+++ b/internal/models/project/settings/settings.go
@@ -30,6 +30,8 @@ var SettingsAttributes = map[string]schema.Attribute{
 	"enable_inactivity":                   boolattr.Default(false),
 	"inactivity_time":                     durationattr.Default("12 minutes", durationattr.MinimumValue("10 minutes")),
 	"test_users_loginid_regexp":           stringattr.Default(""),
+	"test_users_verifier_regexp":          stringattr.Default(""),
+	"test_users_static_otp":               stringattr.Default("", stringattr.OTPValidator),
 	"user_jwt_template":                   stringattr.Optional(),
 	"access_key_jwt_template":             stringattr.Optional(),
 }
@@ -50,6 +52,8 @@ type SettingsModel struct {
 	EnableInactivity                types.Bool   `tfsdk:"enable_inactivity"`
 	InactivityTime                  types.String `tfsdk:"inactivity_time"`
 	TestUsersLoginIDRegExp          types.String `tfsdk:"test_users_loginid_regexp"`
+	TestUsersVerifierRegExp         types.String `tfsdk:"test_users_verifier_regexp"`
+	TestUsersStaticOTP              types.String `tfsdk:"test_users_static_otp"`
 	UserJWTTemplate                 types.String `tfsdk:"user_jwt_template"`
 	AccessKeyJWTTemplate            types.String `tfsdk:"access_key_jwt_template"`
 }
@@ -78,6 +82,9 @@ func (m *SettingsModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.Get(m.EnableInactivity, data, "enableInactivity")
 	durationattr.Get(m.InactivityTime, data, "inactivityTime")
 	stringattr.Get(m.TestUsersLoginIDRegExp, data, "testUserRegex")
+	stringattr.Get(m.TestUsersVerifierRegExp, data, "testUserFixedAuthVerifierRegex")
+	stringattr.Get(m.TestUsersStaticOTP, data, "testUserFixedAuthToken")
+	data["testUserAllowFixedAuth"] = m.TestUsersStaticOTP.ValueString() != ""
 	getJWTTemplate(m.UserJWTTemplate, data, "userTemplateId", "user", h)
 	getJWTTemplate(m.AccessKeyJWTTemplate, data, "keyTemplateId", "key", h)
 	return data
@@ -105,6 +112,12 @@ func (m *SettingsModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.Set(&m.EnableInactivity, data, "enableInactivity")
 	durationattr.Set(&m.InactivityTime, data, "inactivityTime")
 	stringattr.Set(&m.TestUsersLoginIDRegExp, data, "testUserRegex")
+	stringattr.Set(&m.TestUsersVerifierRegExp, data, "testUserFixedAuthVerifierRegex")
+	if data["testUserAllowFixedAuth"] == true {
+		stringattr.Set(&m.TestUsersStaticOTP, data, "testUserFixedAuthToken")
+	} else {
+		m.TestUsersStaticOTP = types.StringValue("")
+	}
 	stringattr.Set(&m.UserJWTTemplate, data, "userTemplateId")
 	stringattr.Set(&m.AccessKeyJWTTemplate, data, "keyTemplateId")
 }

--- a/internal/models/project/settings/settings_test.go
+++ b/internal/models/project/settings/settings_test.go
@@ -180,10 +180,14 @@ func TestSettings(t *testing.T) {
 			Config: p.Config(`
 				project_settings = {
 					test_users_loginid_regexp = "^acmetestuser-[0-9]+@acmecorp.com$"
+					test_users_verifier_regexp = "^acmetestuser-[0-9]+@acmecorp.com$"
+					test_users_static_otp = "123456"
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.test_users_loginid_regexp": "^acmetestuser-[0-9]+@acmecorp.com$",
+				"project_settings.test_users_loginid_regexp":  "^acmetestuser-[0-9]+@acmecorp.com$",
+				"project_settings.test_users_verifier_regexp": "^acmetestuser-[0-9]+@acmecorp.com$",
+				"project_settings.test_users_static_otp":      "123456",
 			}),
 		},
 		resource.TestStep{


### PR DESCRIPTION
## Description
- Add support for `test_users_static_otp` and `test_users_verifier_regexp` for projects that don't have their `environment` set to `production`.

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
