### PR TITLE
Support unknown/null values in string map values

### DIFF
--- a/internal/models/project/connectors/auditwebhook.go
+++ b/internal/models/project/connectors/auditwebhook.go
@@ -33,7 +33,7 @@ type AuditWebhookModel struct {
 
 	BaseURL        types.String             `tfsdk:"base_url"`
 	Authentication *HTTPAuthFieldModel      `tfsdk:"authentication"`
-	Headers        map[string]string        `tfsdk:"headers"`
+	Headers        map[string]types.String  `tfsdk:"headers"`
 	HMACSecret     types.String             `tfsdk:"hmac_secret"`
 	Insecure       types.Bool               `tfsdk:"insecure"`
 	AuditFilters   []*AuditFilterFieldModel `tfsdk:"audit_filters"`
@@ -54,7 +54,7 @@ func (m *AuditWebhookModel) SetValues(h *helpers.Handler, data map[string]any) {
 		if vs, ok := c["headers"].(map[string]any); ok {
 			for k, v := range vs {
 				if s, ok := v.(string); ok {
-					m.Headers[k] = s
+					m.Headers[k] = types.StringValue(s)
 				}
 			}
 		}

--- a/internal/models/project/connectors/genericsmsgateway.go
+++ b/internal/models/project/connectors/genericsmsgateway.go
@@ -31,13 +31,13 @@ type GenericSMSGatewayModel struct {
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 
-	PostURL        types.String        `tfsdk:"post_url"`
-	Sender         types.String        `tfsdk:"sender"`
-	Authentication *HTTPAuthFieldModel `tfsdk:"authentication"`
-	Headers        map[string]string   `tfsdk:"headers"`
-	HMACSecret     types.String        `tfsdk:"hmac_secret"`
-	Insecure       types.Bool          `tfsdk:"insecure"`
-	UseStaticIPs   types.Bool          `tfsdk:"use_static_ips"`
+	PostURL        types.String            `tfsdk:"post_url"`
+	Sender         types.String            `tfsdk:"sender"`
+	Authentication *HTTPAuthFieldModel     `tfsdk:"authentication"`
+	Headers        map[string]types.String `tfsdk:"headers"`
+	HMACSecret     types.String            `tfsdk:"hmac_secret"`
+	Insecure       types.Bool              `tfsdk:"insecure"`
+	UseStaticIPs   types.Bool              `tfsdk:"use_static_ips"`
 }
 
 func (m *GenericSMSGatewayModel) Values(h *helpers.Handler) map[string]any {
@@ -56,7 +56,7 @@ func (m *GenericSMSGatewayModel) SetValues(h *helpers.Handler, data map[string]a
 		if vs, ok := c["headers"].(map[string]any); ok {
 			for k, v := range vs {
 				if s, ok := v.(string); ok {
-					m.Headers[k] = s
+					m.Headers[k] = types.StringValue(s)
 				}
 			}
 		}

--- a/internal/models/project/connectors/http.go
+++ b/internal/models/project/connectors/http.go
@@ -31,13 +31,13 @@ type HTTPModel struct {
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 
-	BaseURL                 types.String        `tfsdk:"base_url"`
-	Authentication          *HTTPAuthFieldModel `tfsdk:"authentication"`
-	Headers                 map[string]string   `tfsdk:"headers"`
-	HMACSecret              types.String        `tfsdk:"hmac_secret"`
-	Insecure                types.Bool          `tfsdk:"insecure"`
-	IncludeHeadersInContext types.Bool          `tfsdk:"include_headers_in_context"`
-	UseStaticIPs            types.Bool          `tfsdk:"use_static_ips"`
+	BaseURL                 types.String            `tfsdk:"base_url"`
+	Authentication          *HTTPAuthFieldModel     `tfsdk:"authentication"`
+	Headers                 map[string]types.String `tfsdk:"headers"`
+	HMACSecret              types.String            `tfsdk:"hmac_secret"`
+	Insecure                types.Bool              `tfsdk:"insecure"`
+	IncludeHeadersInContext types.Bool              `tfsdk:"include_headers_in_context"`
+	UseStaticIPs            types.Bool              `tfsdk:"use_static_ips"`
 }
 
 func (m *HTTPModel) Values(h *helpers.Handler) map[string]any {
@@ -55,7 +55,7 @@ func (m *HTTPModel) SetValues(h *helpers.Handler, data map[string]any) {
 		if vs, ok := c["headers"].(map[string]any); ok {
 			for k, v := range vs {
 				if s, ok := v.(string); ok {
-					m.Headers[k] = s
+					m.Headers[k] = types.StringValue(s)
 				}
 			}
 		}

--- a/internal/models/project/connectors/shared.go
+++ b/internal/models/project/connectors/shared.go
@@ -184,10 +184,12 @@ func (m *AuditFilterFieldModel) SetValues(h *helpers.Handler, data map[string]an
 
 // HTTP Headers
 
-func getHeaders(s map[string]string, data map[string]any, key string) {
+func getHeaders(s map[string]types.String, data map[string]any, key string) {
 	headers := []any{}
 	for k, v := range s {
-		headers = append(headers, map[string]any{"key": k, "value": v})
+		if !v.IsNull() && !v.IsUnknown() {
+			headers = append(headers, map[string]any{"key": k, "value": v.ValueString()})
+		}
 	}
 	data[key] = headers
 }

--- a/tools/terragen/conngen/field.go
+++ b/tools/terragen/conngen/field.go
@@ -58,7 +58,7 @@ func (f *Field) StructType() string {
 	case FieldTypeNumber:
 		return `types.Float64`
 	case FieldTypeObject:
-		return `map[string]string`
+		return `map[string]types.String`
 	case FieldTypeAuditFilters:
 		return `[]*AuditFilterFieldModel`
 	case FieldTypeHTTPAuth:
@@ -153,7 +153,7 @@ func (f *Field) SetValueStatement() string {
 		return fmt.Sprintf(`if vs, ok := c[%q].(map[string]any); ok {
 			for k, v := range vs {
 				if s, ok := v.(string); ok {
-					m.%s[k] = s
+					m.%s[k] = types.StringValue(s)
 				}
 			}	
 		}`, f.Name, f.StructName())


### PR DESCRIPTION
## Description
- Support `unknown`/`null` values in string map values so they can be specified with variables.

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
