### PR TITLE
Feat/session token cookie

### DIFF
--- a/docs/raw/project/settings/settings.md
+++ b/docs/raw/project/settings/settings.md
@@ -32,7 +32,7 @@ for different authentication methods.
 
 
 
-token_response_method
+refresh_token_response_method
 ---------------------
 
 - Type: `string` 
@@ -41,6 +41,14 @@ token_response_method
 Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body`
 or `cookies`. The default value is `response_body`.
 
+session_token_response_method
+---------------------
+
+- Type: `string` 
+- Default: `"response_body"`
+
+Configure how sessions tokens are managed by the Descope SDKs. Must be either `response_body`
+or `cookies`. The default value is `response_body`.
 
 
 cookie_policy

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -2039,7 +2039,7 @@ Optional:
 - `test_users_loginid_regexp` (String) Define a regular expression so that whenever a user is created with a matching login ID it will automatically be marked as a test user.
 - `test_users_static_otp` (String) A 6 digit static OTP code for use with test users.
 - `test_users_verifier_regexp` (String) The pattern of the verifiers that will be used for testing.
-- `token_response_method` (String) Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` or `cookies`. The default value is `response_body`.
+- `session_token_response_method` (String) Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` or `cookies`. The default value is `response_body`.
 - `trusted_device_token_expiration` (String) The expiry time for the trusted device token. The minimum value is "3 minutes".
 - `user_jwt_template` (String) Name of the user JWT Template.
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -784,7 +784,9 @@ var docsSettings = map[string]string{
 	"custom_domain": "",
 	"approved_domains": "The list of approved domains that are allowed for redirect and verification URLs " +
 	                    "for different authentication methods.",
-	"token_response_method": "Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` " +
+	"refresh_token_response_method": "Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` " +
+	                         "or `cookies`. The default value is `response_body`.",
+	"session_token_response_method": "Configure how session tokens are managed by the Descope SDKs. Must be either `response_body` " +
 	                         "or `cookies`. The default value is `response_body`.",
 	"cookie_policy": "Use \"strict\", \"lax\" or \"none\". To read more about custom domain and cookie policy " +
 	                 "click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",

--- a/internal/models/project/settings/settings_test.go
+++ b/internal/models/project/settings/settings_test.go
@@ -196,17 +196,20 @@ func TestSettings(t *testing.T) {
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.token_response_method": "response_body",
+				"project_settings.session_token_response_method": "response_body",
+				"project_settings.refresh_token_response_method": "response_body",
 			}),
 		},
 		resource.TestStep{
 			Config: p.Config(`
 				project_settings = {
-					token_response_method = "cookies"
+					session_token_response_method = "cookies"
+					refresh_token_response_method = "cookies"
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.token_response_method": "cookies",
+				"project_settings.session_token_response_method": "cookies",
+				"project_settings.refresh_token_response_method": "cookies",
 			}),
 		},
 		resource.TestStep{
@@ -215,7 +218,8 @@ func TestSettings(t *testing.T) {
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.token_response_method": "response_body",
+				"project_settings.session_token_response_method": "response_body",
+				"project_settings.refresh_token_response_method": "response_body",
 			}),
 		},
 		resource.TestStep{


### PR DESCRIPTION
## Description
- The existing `token_response_method` property would only update the token response method for the cookie token. I noticed the management API allowed `sessionTokenResponseMethod` to be changed which would apply to the session token. I updated the provider to allow this field to be changed. For clarify I also renamed the existing `token_response_method` to `refresh_token_response_method`.

## Must
- [x] Acceptance Tests
- [x] Schema Compatibility
- [x] Documentation Updates
