### PR TITLE
Allow setting static OTP for test users in production projects

### DIFF
--- a/internal/models/project/project.go
+++ b/internal/models/project/project.go
@@ -58,7 +58,6 @@ type ProjectModel struct {
 }
 
 func (m *ProjectModel) Values(h *helpers.Handler) map[string]any {
-	m.Check(h)
 	data := map[string]any{}
 	data["version"] = helpers.ModelVersion
 	stringattr.Get(m.Name, data, "name")
@@ -95,16 +94,6 @@ func (m *ProjectModel) SetValues(h *helpers.Handler, data map[string]any) {
 	objectattr.Set(&m.JWTTemplates, data, "jwtTemplates", h)
 	objectattr.Set(&m.Styles, data, "styles", h)
 	mapattr.Set(&m.Flows, data, "flows", h)
-}
-
-func (m *ProjectModel) Check(h *helpers.Handler) {
-	if m.Environment.ValueString() == "production" {
-		if v := m.Settings; v != nil {
-			if v.TestUsersStaticOTP.ValueString() != "" {
-				h.Error("Invalid Production Settings", "The test_users_static_otp attribute cannot be used with production projects")
-			}
-		}
-	}
 }
 
 func (m *ProjectModel) References(ctx context.Context) helpers.ReferencesMap {

--- a/internal/models/project/settings/settings.go
+++ b/internal/models/project/settings/settings.go
@@ -166,6 +166,10 @@ func (m *SettingsModel) Check(h *helpers.Handler) {
 			h.Invalid("The cookie_domain attribute must be set to the same domain as the custom_domain attribute or one of its top level domains")
 		}
 	}
+
+	if (m.TestUsersStaticOTP.ValueString() == "") != (m.TestUsersVerifierRegExp.ValueString() == "") {
+		h.Invalid("The test_users_static_otp and test_users_verifier_regexp attributes must be set together")
+	}
 }
 
 func getJWTTemplate(field types.String, data map[string]any, key string, typ string, h *helpers.Handler) {

--- a/internal/models/project/settings/settings_test.go
+++ b/internal/models/project/settings/settings_test.go
@@ -179,14 +179,14 @@ func TestSettings(t *testing.T) {
 		resource.TestStep{
 			Config: p.Config(`
 				project_settings = {
-					test_users_loginid_regexp = "^acmetestuser-[0-9]+@acmecorp.com$"
-					test_users_verifier_regexp = "^acmetestuser-[0-9]+@acmecorp.com$"
+					test_users_loginid_regexp = "^foo-[0-9]+@acmecorp.com$"
+					test_users_verifier_regexp = "^bar-[0-9]+@acmecorp.com$"
 					test_users_static_otp = "123456"
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.test_users_loginid_regexp":  "^acmetestuser-[0-9]+@acmecorp.com$",
-				"project_settings.test_users_verifier_regexp": "^acmetestuser-[0-9]+@acmecorp.com$",
+				"project_settings.test_users_loginid_regexp":  "^foo-[0-9]+@acmecorp.com$",
+				"project_settings.test_users_verifier_regexp": "^bar-[0-9]+@acmecorp.com$",
 				"project_settings.test_users_static_otp":      "123456",
 			}),
 		},


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/9708

## Description
- Allow setting static OTP for test users in production projects

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
