### PR TITLE
Add support for upgrading existing SMTP connectors to use static IPs

### DIFF
--- a/docs/raw/project/connectors/smtp.md
+++ b/docs/raw/project/connectors/smtp.md
@@ -31,6 +31,15 @@ authentication
 
 
 
+use_static_ips
+--------------
+
+- Type: `bool` 
+
+Whether the connector should send all requests from specific static IPs.
+
+
+
 
 
 SMTPAuthField

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1725,6 +1725,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `use_static_ips` (Boolean) Whether the connector should send all requests from specific static IPs.
 
 Read-Only:
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -664,6 +664,7 @@ var docsSMTP = map[string]string{
 	"sender": "The sender details that should be displayed in the email message.",
 	"server": "",
 	"authentication": "",
+	"use_static_ips": "Whether the connector should send all requests from specific static IPs.",
 }
 
 var docsSMTPAuthField = map[string]string{

--- a/internal/models/project/connectors/connectors.go
+++ b/internal/models/project/connectors/connectors.go
@@ -2,12 +2,16 @@ package connectors
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/listattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/objectattr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var ConnectorsValidator = objectattr.NewValidator[ConnectorsModel]("must have unique connector names")
@@ -316,4 +320,13 @@ func (m *ConnectorsModel) Modify(ctx context.Context, state *ConnectorsModel, di
 	helpers.MatchModels(ctx, m.Traceable, state.Traceable)
 	helpers.MatchModels(ctx, m.TwilioCore, state.TwilioCore)
 	helpers.MatchModels(ctx, m.TwilioVerify, state.TwilioVerify)
+
+	// Upgrade existing identifiers for SMTP connectors to support static IPs
+	for _, c := range m.SMTP {
+		id := c.ID.ValueString()
+		if v := strings.TrimPrefix(id, "MP"); v != id && c.UseStaticIPs.ValueBool() {
+			c.ID = types.StringValue("CI" + v)
+			tflog.Info(ctx, fmt.Sprintf("Upgrading identifier for SMTP connector from '%s' to '%s'", id, c.ID.ValueString()))
+		}
+	}
 }

--- a/internal/models/project/connectors/shared_test.go
+++ b/internal/models/project/connectors/shared_test.go
@@ -1,0 +1,45 @@
+package connectors_test
+
+import (
+	"testing"
+
+	"github.com/descope/terraform-provider-descope/tools/testacc"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestConnectorsShared(t *testing.T) {
+	p := testacc.Project(t)
+	testacc.Run(t,
+		resource.TestStep{
+			Config: p.Config(`
+				connectors = {
+					"smtp": [
+						{
+							name = "My SMTP Connector"
+							description = ""
+							server = {
+								host = "example.com"
+								port = 587
+							}
+							sender = {
+								email = "foo@bar.com"
+								name = "Foo Bar"
+							}
+							authentication = {
+								username = "foo"
+								password = "bar"
+							}
+						}
+					]
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"connectors.smtp.#":                1,
+				"connectors.smtp.0.id":             testacc.AttributeMatchesPattern(`^(CI|MP)`),
+				"connectors.smtp.0.name":           "My SMTP Connector",
+				"connectors.smtp.0.description":    "",
+				"connectors.smtp.0.use_static_ips": false,
+			}),
+		},
+	)
+}

--- a/tools/terragen/conngen/connector.go
+++ b/tools/terragen/conngen/connector.go
@@ -25,6 +25,10 @@ func (c *Connector) IsExperimental() bool {
 	return c.Extra["experimental"] == true
 }
 
+func (c *Connector) IsSkipped() bool {
+	return c.ID == "smtp-v2"
+}
+
 func (c *Connector) SupportsStaticIPs() bool {
 	return c.Extra["supportStaticIps"] == true
 }

--- a/tools/terragen/conngen/connectors.go
+++ b/tools/terragen/conngen/connectors.go
@@ -77,6 +77,11 @@ func (c *Connectors) readConnector(path string) {
 		return
 	}
 
+	if connector.IsSkipped() {
+		utils.Debug(1, "- %s (skipped)", connector.ID)
+		return
+	}
+
 	if connector.SupportsStaticIPs() {
 		connector.Fields = append(connector.Fields, UseStaticIPsField)
 	}

--- a/tools/terragen/conngen/connectors.gotmpl
+++ b/tools/terragen/conngen/connectors.gotmpl
@@ -2,12 +2,16 @@ package connectors
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/listattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/objectattr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var ConnectorsValidator = objectattr.NewValidator[ConnectorsModel]("must have unique connector names")
@@ -64,4 +68,13 @@ func (m *ConnectorsModel) Modify(ctx context.Context, state *ConnectorsModel, di
     {{- range .Connectors }}
     helpers.MatchModels(ctx, m.{{.StructName}}, state.{{.StructName}})
     {{- end }}
+
+	// Upgrade existing identifiers for SMTP connectors to support static IPs
+	for _, c := range m.SMTP {
+		id := c.ID.ValueString()
+		if v := strings.TrimPrefix(id, "MP"); v != id && c.UseStaticIPs.ValueBool() {
+			c.ID = types.StringValue("CI" + v)
+			tflog.Info(ctx, fmt.Sprintf("Upgrading identifier for SMTP connector from '%s' to '%s'", id, c.ID.ValueString()))
+		}
+	}
 }


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/9860

## Description
- Add support for upgrading existing SMTP connectors to use static IPs

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
