### PR TITLE
Add graceful deprecation for old refresh token attributes and separate session cookie attributes

### DIFF
--- a/docs/raw/project/settings/settings.md
+++ b/docs/raw/project/settings/settings.md
@@ -9,7 +9,7 @@ app_url
 
 - Type: `string` 
 
-// description for app_url
+The URL which your application resides on.
 
 
 
@@ -18,7 +18,8 @@ custom_domain
 
 - Type: `string` 
 
-// description for custom_domain
+A custom CNAME that's configured to point to `cname.descope.com`. Read more about custom
+domains and cookie policy [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 
 
 
@@ -29,45 +30,6 @@ approved_domains
 
 The list of approved domains that are allowed for redirect and verification URLs
 for different authentication methods.
-
-
-
-refresh_token_response_method
----------------------
-
-- Type: `string` 
-- Default: `"response_body"`
-
-Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body`
-or `cookies`. The default value is `response_body`.
-
-session_token_response_method
----------------------
-
-- Type: `string` 
-- Default: `"response_body"`
-
-Configure how sessions tokens are managed by the Descope SDKs. Must be either `response_body`
-or `cookies`. The default value is `response_body`.
-
-
-cookie_policy
--------------
-
-- Type: `string` 
-
-Use "strict", "lax" or "none". To read more about custom domain and cookie policy
-click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
-
-
-
-cookie_domain
--------------
-
-- Type: `string` 
-
-The domain name for custom domain set up. To read more about custom domain and
-cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 
 
 
@@ -91,6 +53,38 @@ such as "4 weeks", "14 days", etc. The minimum value is "3 minutes".
 
 
 
+refresh_token_response_method
+-----------------------------
+
+- Type: `string` 
+- Default: `"response_body"`
+
+Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body`
+or `cookies`. The default value is `response_body`.
+
+
+
+refresh_token_cookie_policy
+---------------------------
+
+- Type: `string` 
+- Default: `"none"`
+
+Use `strict`, `lax` or `none`. Read more about custom domains and cookie policy
+[here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+
+
+
+refresh_token_cookie_domain
+---------------------------
+
+- Type: `string` 
+
+The domain name for refresh token cookies. To read more about custom domain and
+cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+
+
+
 session_token_expiration
 ------------------------
 
@@ -98,6 +92,38 @@ session_token_expiration
 
 The expiry time of the session token, used for accessing the application's resources. The value
 needs to be at least 3 minutes and can't be longer than the refresh token expiration.
+
+
+
+session_token_response_method
+-----------------------------
+
+- Type: `string` 
+- Default: `"response_body"`
+
+Configure how sessions tokens are managed by the Descope SDKs. Must be either `response_body`
+or `cookies`. The default value is `response_body`.
+
+
+
+session_token_cookie_policy
+---------------------------
+
+- Type: `string` 
+- Default: `"none"`
+
+Use `strict`, `lax` or `none`. Read more about custom domains and cookie policy
+[here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+
+
+
+session_token_cookie_domain
+---------------------------
+
+- Type: `string` 
+
+The domain name for session token cookies. To read more about custom domain and
+cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 
 
 
@@ -193,3 +219,30 @@ access_key_jwt_template
 - Type: `string` 
 
 Name of the access key JWT Template.
+
+
+
+token_response_method
+---------------------
+
+- Type: `string` 
+
+Deprecated.
+
+
+
+cookie_policy
+-------------
+
+- Type: `string` 
+
+Deprecated.
+
+
+
+cookie_domain
+-------------
+
+- Type: `string` 
+
+Deprecated.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -2026,21 +2026,27 @@ Optional:
 
 - `access_key_jwt_template` (String) Name of the access key JWT Template.
 - `access_key_session_token_expiration` (String) The expiry time for access key session tokens. Use values such as "10 minutes", "4 hours", etc. The value needs to be at least 3 minutes and can't be longer than 4 weeks.
-- `app_url` (String)
+- `app_url` (String) The URL which your application resides on.
 - `approved_domains` (List of String) The list of approved domains that are allowed for redirect and verification URLs for different authentication methods.
-- `cookie_domain` (String) The domain name for custom domain set up. To read more about custom domain and cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
-- `cookie_policy` (String) Use "strict", "lax" or "none". To read more about custom domain and cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
-- `custom_domain` (String)
+- `cookie_domain` (String, Deprecated) Deprecated.
+- `cookie_policy` (String, Deprecated) Deprecated.
+- `custom_domain` (String) A custom CNAME that's configured to point to `cname.descope.com`. Read more about custom domains and cookie policy [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 - `enable_inactivity` (Boolean) Use `True` to enable session inactivity. To read more about session inactivity click [here](https://docs.descope.com/project-settings#session-inactivity).
 - `inactivity_time` (String) The session inactivity time. Use values such as "15 minutes", "1 hour", etc. The minimum value is "10 minutes".
+- `refresh_token_cookie_domain` (String) The domain name for refresh token cookies. To read more about custom domain and cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+- `refresh_token_cookie_policy` (String) Use `strict`, `lax` or `none`. Read more about custom domains and cookie policy [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 - `refresh_token_expiration` (String) The expiry time for the refresh token, after which the user must log in again. Use values such as "4 weeks", "14 days", etc. The minimum value is "3 minutes".
+- `refresh_token_response_method` (String) Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` or `cookies`. The default value is `response_body`.
 - `refresh_token_rotation` (Boolean) Every time the user refreshes their session token via their refresh token, the refresh token itself is also updated to a new one.
+- `session_token_cookie_domain` (String) The domain name for session token cookies. To read more about custom domain and cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+- `session_token_cookie_policy` (String) Use `strict`, `lax` or `none`. Read more about custom domains and cookie policy [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 - `session_token_expiration` (String) The expiry time of the session token, used for accessing the application's resources. The value needs to be at least 3 minutes and can't be longer than the refresh token expiration.
+- `session_token_response_method` (String) Configure how sessions tokens are managed by the Descope SDKs. Must be either `response_body` or `cookies`. The default value is `response_body`.
 - `step_up_token_expiration` (String) The expiry time for the step up token, after which it will not be valid and the user will automatically go back to the session token.
 - `test_users_loginid_regexp` (String) Define a regular expression so that whenever a user is created with a matching login ID it will automatically be marked as a test user.
 - `test_users_static_otp` (String) A 6 digit static OTP code for use with test users.
 - `test_users_verifier_regexp` (String) The pattern of the verifiers that will be used for testing.
-- `session_token_response_method` (String) Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` or `cookies`. The default value is `response_body`.
+- `token_response_method` (String, Deprecated) Deprecated.
 - `trusted_device_token_expiration` (String) The expiry time for the trusted device token. The minimum value is "3 minutes".
 - `user_jwt_template` (String) Name of the user JWT Template.
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -781,24 +781,29 @@ var docsInviteSettings = map[string]string{
 }
 
 var docsSettings = map[string]string{
-	"app_url": "",
-	"custom_domain": "",
+	"app_url": "The URL which your application resides on.",
+	"custom_domain": "A custom CNAME that's configured to point to `cname.descope.com`. Read more about custom " +
+	                 "domains and cookie policy [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
 	"approved_domains": "The list of approved domains that are allowed for redirect and verification URLs " +
 	                    "for different authentication methods.",
-	"refresh_token_response_method": "Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` " +
-	                         "or `cookies`. The default value is `response_body`.",
-	"session_token_response_method": "Configure how session tokens are managed by the Descope SDKs. Must be either `response_body` " +
-	                         "or `cookies`. The default value is `response_body`.",
-	"cookie_policy": "Use \"strict\", \"lax\" or \"none\". To read more about custom domain and cookie policy " +
-	                 "click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
-	"cookie_domain": "The domain name for custom domain set up. To read more about custom domain and " +
-	                 "cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
 	"refresh_token_rotation": "Every time the user refreshes their session token via their refresh token, the " +
 	                          "refresh token itself is also updated to a new one.",
 	"refresh_token_expiration": "The expiry time for the refresh token, after which the user must log in again. Use values " +
 	                            "such as \"4 weeks\", \"14 days\", etc. The minimum value is \"3 minutes\".",
+	"refresh_token_response_method": "Configure how refresh tokens are managed by the Descope SDKs. Must be either `response_body` " +
+	                                 "or `cookies`. The default value is `response_body`.",
+	"refresh_token_cookie_policy": "Use `strict`, `lax` or `none`. Read more about custom domains and cookie policy " +
+	                               "[here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
+	"refresh_token_cookie_domain": "The domain name for refresh token cookies. To read more about custom domain and " +
+	                               "cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
 	"session_token_expiration": "The expiry time of the session token, used for accessing the application's resources. The value " +
 	                            "needs to be at least 3 minutes and can't be longer than the refresh token expiration.",
+	"session_token_response_method": "Configure how sessions tokens are managed by the Descope SDKs. Must be either `response_body` " +
+	                                 "or `cookies`. The default value is `response_body`.",
+	"session_token_cookie_policy": "Use `strict`, `lax` or `none`. Read more about custom domains and cookie policy " +
+	                               "[here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
+	"session_token_cookie_domain": "The domain name for session token cookies. To read more about custom domain and " +
+	                               "cookie policy click [here](https://docs.descope.com/how-to-deploy-to-production/custom-domain).",
 	"step_up_token_expiration": "The expiry time for the step up token, after which it will not be valid and the user will " +
 	                            "automatically go back to the session token.",
 	"trusted_device_token_expiration": "The expiry time for the trusted device token. The minimum value is \"3 minutes\".",
@@ -814,6 +819,9 @@ var docsSettings = map[string]string{
 	"test_users_static_otp": "A 6 digit static OTP code for use with test users.",
 	"user_jwt_template": "Name of the user JWT Template.",
 	"access_key_jwt_template": "Name of the access key JWT Template.",
+	"token_response_method": "Deprecated.",
+	"cookie_policy": "Deprecated.",
+	"cookie_domain": "Deprecated.",
 }
 
 var docsEmailService = map[string]string{

--- a/internal/models/helpers/objectattr/modifiers.go
+++ b/internal/models/helpers/objectattr/modifiers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -16,7 +15,7 @@ func NewModifier[T any, M modifiableModel[T]](description string) planmodifier.O
 
 type modifiableModel[T any] interface {
 	helpers.Model[T]
-	Modify(ctx context.Context, state *T, diags *diag.Diagnostics)
+	Modify(h *helpers.Handler, state *T, config *T)
 }
 
 // Implementation
@@ -40,11 +39,13 @@ func (v *objectModifier[T, M]) PlanModifyObject(ctx context.Context, req planmod
 
 	plan := helpers.ModelFromObject[T, M](ctx, req.PlanValue, &resp.Diagnostics)
 	state := helpers.ModelFromObject[T, M](ctx, req.StateValue, &resp.Diagnostics)
+	config := helpers.ModelFromObject[T, M](ctx, req.ConfigValue, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	plan.Modify(ctx, state, &resp.Diagnostics)
+	handler := helpers.NewHandler(ctx, &resp.Diagnostics, helpers.ReferencesMap{})
+	plan.Modify(handler, state, config)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/models/helpers/stringattr/string.go
+++ b/internal/models/helpers/stringattr/string.go
@@ -65,6 +65,20 @@ func Default(value string, validators ...validator.String) schema.StringAttribut
 	}
 }
 
+func Deprecated(message string, validators ...validator.String) schema.StringAttribute {
+	return schema.StringAttribute{
+		Optional:           true,
+		Computed:           true,
+		DeprecationMessage: message + " This attribute will be removed in a future version of the provider.",
+		Validators:         validators,
+		Default:            NullDefault(),
+	}
+}
+
+func Renamed(oldname, newname string, validators ...validator.String) schema.StringAttribute {
+	return Deprecated("The "+oldname+" attribute has been renamed, set the "+newname+" attribute instead.", validators...)
+}
+
 func Get(s types.String, data map[string]any, key string) {
 	if !s.IsNull() && !s.IsUnknown() {
 		data[key] = s.ValueString()

--- a/internal/models/project/connectors/connectors.go
+++ b/internal/models/project/connectors/connectors.go
@@ -2,16 +2,13 @@ package connectors
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/listattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/objectattr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var ConnectorsValidator = objectattr.NewValidator[ConnectorsModel]("must have unique connector names")
@@ -280,53 +277,53 @@ func (m *ConnectorsModel) Validate(h *helpers.Handler) {
 	}
 }
 
-func (m *ConnectorsModel) Modify(ctx context.Context, state *ConnectorsModel, diags *diag.Diagnostics) {
-	helpers.MatchModels(ctx, m.AbuseIPDB, state.AbuseIPDB)
-	helpers.MatchModels(ctx, m.Amplitude, state.Amplitude)
-	helpers.MatchModels(ctx, m.AuditWebhook, state.AuditWebhook)
-	helpers.MatchModels(ctx, m.AWSS3, state.AWSS3)
-	helpers.MatchModels(ctx, m.AWSTranslate, state.AWSTranslate)
-	helpers.MatchModels(ctx, m.Clear, state.Clear)
-	helpers.MatchModels(ctx, m.Datadog, state.Datadog)
-	helpers.MatchModels(ctx, m.DevRevGrow, state.DevRevGrow)
-	helpers.MatchModels(ctx, m.Docebo, state.Docebo)
-	helpers.MatchModels(ctx, m.Fingerprint, state.Fingerprint)
-	helpers.MatchModels(ctx, m.FingerprintDescope, state.FingerprintDescope)
-	helpers.MatchModels(ctx, m.Forter, state.Forter)
-	helpers.MatchModels(ctx, m.GenericSMSGateway, state.GenericSMSGateway)
-	helpers.MatchModels(ctx, m.GoogleCloudTranslation, state.GoogleCloudTranslation)
-	helpers.MatchModels(ctx, m.HIBP, state.HIBP)
-	helpers.MatchModels(ctx, m.HTTP, state.HTTP)
-	helpers.MatchModels(ctx, m.HubSpot, state.HubSpot)
-	helpers.MatchModels(ctx, m.Incode, state.Incode)
-	helpers.MatchModels(ctx, m.Intercom, state.Intercom)
-	helpers.MatchModels(ctx, m.Lokalise, state.Lokalise)
-	helpers.MatchModels(ctx, m.MParticle, state.MParticle)
-	helpers.MatchModels(ctx, m.NewRelic, state.NewRelic)
-	helpers.MatchModels(ctx, m.Recaptcha, state.Recaptcha)
-	helpers.MatchModels(ctx, m.RecaptchaEnterprise, state.RecaptchaEnterprise)
-	helpers.MatchModels(ctx, m.Rekognition, state.Rekognition)
-	helpers.MatchModels(ctx, m.Salesforce, state.Salesforce)
-	helpers.MatchModels(ctx, m.SalesforceMarketingCloud, state.SalesforceMarketingCloud)
-	helpers.MatchModels(ctx, m.Segment, state.Segment)
-	helpers.MatchModels(ctx, m.SendGrid, state.SendGrid)
-	helpers.MatchModels(ctx, m.SES, state.SES)
-	helpers.MatchModels(ctx, m.Slack, state.Slack)
-	helpers.MatchModels(ctx, m.Smartling, state.Smartling)
-	helpers.MatchModels(ctx, m.SMTP, state.SMTP)
-	helpers.MatchModels(ctx, m.SNS, state.SNS)
-	helpers.MatchModels(ctx, m.SumoLogic, state.SumoLogic)
-	helpers.MatchModels(ctx, m.Telesign, state.Telesign)
-	helpers.MatchModels(ctx, m.Traceable, state.Traceable)
-	helpers.MatchModels(ctx, m.TwilioCore, state.TwilioCore)
-	helpers.MatchModels(ctx, m.TwilioVerify, state.TwilioVerify)
+func (m *ConnectorsModel) Modify(h *helpers.Handler, state *ConnectorsModel, config *ConnectorsModel) {
+	helpers.MatchModels(h.Ctx, m.AbuseIPDB, state.AbuseIPDB)
+	helpers.MatchModels(h.Ctx, m.Amplitude, state.Amplitude)
+	helpers.MatchModels(h.Ctx, m.AuditWebhook, state.AuditWebhook)
+	helpers.MatchModels(h.Ctx, m.AWSS3, state.AWSS3)
+	helpers.MatchModels(h.Ctx, m.AWSTranslate, state.AWSTranslate)
+	helpers.MatchModels(h.Ctx, m.Clear, state.Clear)
+	helpers.MatchModels(h.Ctx, m.Datadog, state.Datadog)
+	helpers.MatchModels(h.Ctx, m.DevRevGrow, state.DevRevGrow)
+	helpers.MatchModels(h.Ctx, m.Docebo, state.Docebo)
+	helpers.MatchModels(h.Ctx, m.Fingerprint, state.Fingerprint)
+	helpers.MatchModels(h.Ctx, m.FingerprintDescope, state.FingerprintDescope)
+	helpers.MatchModels(h.Ctx, m.Forter, state.Forter)
+	helpers.MatchModels(h.Ctx, m.GenericSMSGateway, state.GenericSMSGateway)
+	helpers.MatchModels(h.Ctx, m.GoogleCloudTranslation, state.GoogleCloudTranslation)
+	helpers.MatchModels(h.Ctx, m.HIBP, state.HIBP)
+	helpers.MatchModels(h.Ctx, m.HTTP, state.HTTP)
+	helpers.MatchModels(h.Ctx, m.HubSpot, state.HubSpot)
+	helpers.MatchModels(h.Ctx, m.Incode, state.Incode)
+	helpers.MatchModels(h.Ctx, m.Intercom, state.Intercom)
+	helpers.MatchModels(h.Ctx, m.Lokalise, state.Lokalise)
+	helpers.MatchModels(h.Ctx, m.MParticle, state.MParticle)
+	helpers.MatchModels(h.Ctx, m.NewRelic, state.NewRelic)
+	helpers.MatchModels(h.Ctx, m.Recaptcha, state.Recaptcha)
+	helpers.MatchModels(h.Ctx, m.RecaptchaEnterprise, state.RecaptchaEnterprise)
+	helpers.MatchModels(h.Ctx, m.Rekognition, state.Rekognition)
+	helpers.MatchModels(h.Ctx, m.Salesforce, state.Salesforce)
+	helpers.MatchModels(h.Ctx, m.SalesforceMarketingCloud, state.SalesforceMarketingCloud)
+	helpers.MatchModels(h.Ctx, m.Segment, state.Segment)
+	helpers.MatchModels(h.Ctx, m.SendGrid, state.SendGrid)
+	helpers.MatchModels(h.Ctx, m.SES, state.SES)
+	helpers.MatchModels(h.Ctx, m.Slack, state.Slack)
+	helpers.MatchModels(h.Ctx, m.Smartling, state.Smartling)
+	helpers.MatchModels(h.Ctx, m.SMTP, state.SMTP)
+	helpers.MatchModels(h.Ctx, m.SNS, state.SNS)
+	helpers.MatchModels(h.Ctx, m.SumoLogic, state.SumoLogic)
+	helpers.MatchModels(h.Ctx, m.Telesign, state.Telesign)
+	helpers.MatchModels(h.Ctx, m.Traceable, state.Traceable)
+	helpers.MatchModels(h.Ctx, m.TwilioCore, state.TwilioCore)
+	helpers.MatchModels(h.Ctx, m.TwilioVerify, state.TwilioVerify)
 
 	// Upgrade existing identifiers for SMTP connectors to support static IPs
 	for _, c := range m.SMTP {
 		id := c.ID.ValueString()
 		if v := strings.TrimPrefix(id, "MP"); v != id && c.UseStaticIPs.ValueBool() {
 			c.ID = types.StringValue("CI" + v)
-			tflog.Info(ctx, fmt.Sprintf("Upgrading identifier for SMTP connector from '%s' to '%s'", id, c.ID.ValueString()))
+			h.Log("Upgrading identifier for SMTP connector from '%s' to '%s'", id, c.ID.ValueString())
 		}
 	}
 }

--- a/internal/models/project/project.go
+++ b/internal/models/project/project.go
@@ -28,7 +28,7 @@ var ProjectAttributes = map[string]schema.Attribute{
 	"name":             stringattr.Required(),
 	"environment":      stringattr.Optional(stringvalidator.OneOf("", "production")),
 	"tags":             strlistattr.Optional(listvalidator.ValueStringsAre(stringvalidator.LengthBetween(1, 50))),
-	"project_settings": objectattr.Optional(settings.SettingsAttributes),
+	"project_settings": objectattr.Optional(settings.SettingsAttributes, settings.SettingsValidator),
 	"invite_settings":  objectattr.Optional(settings.InviteSettingsAttributes),
 	"authentication":   objectattr.Optional(authentication.AuthenticationAttributes),
 	"authorization":    objectattr.Optional(authorization.AuthorizationAttributes, authorization.AuthorizationValidator),

--- a/internal/models/project/settings/settings.go
+++ b/internal/models/project/settings/settings.go
@@ -7,6 +7,7 @@ import (
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/boolattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/durationattr"
+	"github.com/descope/terraform-provider-descope/internal/models/helpers/objectattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/stringattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/strlistattr"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -14,17 +15,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var SettingsValidator = objectattr.NewValidator[SettingsModel]("must have a valid configuration")
+
 var SettingsAttributes = map[string]schema.Attribute{
 	"app_url":                             stringattr.Optional(),
 	"custom_domain":                       stringattr.Optional(),
 	"approved_domains":                    strlistattr.Optional(strlistattr.CommaSeparatedListValidator),
-	"refresh_token_response_method":       stringattr.Default("response_body", stringvalidator.OneOf("cookies", "response_body")),
-	"session_token_response_method":       stringattr.Default("response_body", stringvalidator.OneOf("cookies", "response_body")),
-	"cookie_policy":                       stringattr.Optional(stringvalidator.OneOf("strict", "lax", "none")),
-	"cookie_domain":                       stringattr.Default(""),
 	"refresh_token_rotation":              boolattr.Default(false),
 	"refresh_token_expiration":            durationattr.Default("4 weeks", durationattr.MinimumValue("3 minutes")),
+	"refresh_token_response_method":       stringattr.Default("response_body", stringvalidator.OneOf("cookies", "response_body")),
+	"refresh_token_cookie_policy":         stringattr.Default("none", stringvalidator.OneOf("strict", "lax", "none")),
+	"refresh_token_cookie_domain":         stringattr.Default(""),
 	"session_token_expiration":            durationattr.Default("10 minutes", durationattr.MinimumValue("3 minutes")),
+	"session_token_response_method":       stringattr.Default("response_body", stringvalidator.OneOf("cookies", "response_body")),
+	"session_token_cookie_policy":         stringattr.Default("none", stringvalidator.OneOf("strict", "lax", "none")),
+	"session_token_cookie_domain":         stringattr.Default(""),
 	"step_up_token_expiration":            durationattr.Default("10 minutes", durationattr.MinimumValue("3 minutes")),
 	"trusted_device_token_expiration":     durationattr.Default("365 days", durationattr.MinimumValue("3 minutes")),
 	"access_key_session_token_expiration": durationattr.Default("10 minutes", durationattr.MinimumValue("3 minutes")),
@@ -35,19 +40,26 @@ var SettingsAttributes = map[string]schema.Attribute{
 	"test_users_static_otp":               stringattr.Default("", stringattr.OTPValidator),
 	"user_jwt_template":                   stringattr.Optional(),
 	"access_key_jwt_template":             stringattr.Optional(),
+
+	// Deprecated
+	"token_response_method": stringattr.Renamed("token_response_method", "refresh_token_response_method"),
+	"cookie_policy":         stringattr.Renamed("cookie_policy", "refresh_token_cookie_policy"),
+	"cookie_domain":         stringattr.Renamed("cookie_domain", "refresh_token_cookie_domain"),
 }
 
 type SettingsModel struct {
 	AppURL                          types.String `tfsdk:"app_url"`
 	CustomDomain                    types.String `tfsdk:"custom_domain"`
 	ApprovedDomain                  []string     `tfsdk:"approved_domains"`
-	RefreshTokenResponseMethod      types.String `tfsdk:"refresh_token_response_method"`
-	SessionTokenResponseMethod      types.String `tfsdk:"session_token_response_method"`
-	CookiePolicy                    types.String `tfsdk:"cookie_policy"`
-	CookieDomain                    types.String `tfsdk:"cookie_domain"`
 	RefreshTokenRotation            types.Bool   `tfsdk:"refresh_token_rotation"`
 	RefreshTokenExpiration          types.String `tfsdk:"refresh_token_expiration"`
+	RefreshTokenResponseMethod      types.String `tfsdk:"refresh_token_response_method"`
+	RefreshTokenCookiePolicy        types.String `tfsdk:"refresh_token_cookie_policy"`
+	RefreshTokenCookieDomain        types.String `tfsdk:"refresh_token_cookie_domain"`
 	SessionTokenExpiration          types.String `tfsdk:"session_token_expiration"`
+	SessionTokenResponseMethod      types.String `tfsdk:"session_token_response_method"`
+	SessionTokenCookiePolicy        types.String `tfsdk:"session_token_cookie_policy"`
+	SessionTokenCookieDomain        types.String `tfsdk:"session_token_cookie_domain"`
 	StepUpTokenExpiration           types.String `tfsdk:"step_up_token_expiration"`
 	TrustedDeviceTokenExpiration    types.String `tfsdk:"trusted_device_token_expiration"`
 	AccessKeySessionTokenExpiration types.String `tfsdk:"access_key_session_token_expiration"`
@@ -58,6 +70,11 @@ type SettingsModel struct {
 	TestUsersStaticOTP              types.String `tfsdk:"test_users_static_otp"`
 	UserJWTTemplate                 types.String `tfsdk:"user_jwt_template"`
 	AccessKeyJWTTemplate            types.String `tfsdk:"access_key_jwt_template"`
+
+	// Deprecated
+	TokenResponseMethod types.String `tfsdk:"token_response_method"`
+	CookiePolicy        types.String `tfsdk:"cookie_policy"`
+	CookieDomain        types.String `tfsdk:"cookie_domain"`
 }
 
 func (m *SettingsModel) Values(h *helpers.Handler) map[string]any {
@@ -66,6 +83,8 @@ func (m *SettingsModel) Values(h *helpers.Handler) map[string]any {
 	stringattr.Get(m.AppURL, data, "appUrl")
 	stringattr.Get(m.CustomDomain, data, "customDomain")
 	strlistattr.GetCommaSeparated(m.ApprovedDomain, data, "trustedDomains")
+	boolattr.Get(m.RefreshTokenRotation, data, "rotateJwt")
+	durationattr.Get(m.RefreshTokenExpiration, data, "refreshTokenExpiration")
 	if s := m.RefreshTokenResponseMethod.ValueString(); s == "cookies" {
 		data["tokenResponseMethod"] = "cookie"
 	} else if s == "response_body" {
@@ -73,6 +92,9 @@ func (m *SettingsModel) Values(h *helpers.Handler) map[string]any {
 	} else if s != "" {
 		panic("unexpected refresh_token_response_method value: " + s)
 	}
+	stringattr.Get(m.RefreshTokenCookiePolicy, data, "cookiePolicy")
+	stringattr.Get(m.RefreshTokenCookieDomain, data, "domain")
+	durationattr.Get(m.SessionTokenExpiration, data, "sessionTokenExpiration")
 	if s := m.SessionTokenResponseMethod.ValueString(); s == "cookies" {
 		data["sessionTokenResponseMethod"] = "cookie"
 	} else if s == "response_body" {
@@ -80,11 +102,8 @@ func (m *SettingsModel) Values(h *helpers.Handler) map[string]any {
 	} else if s != "" {
 		panic("unexpected session_token_response_method value: " + s)
 	}
-	stringattr.Get(m.CookiePolicy, data, "cookiePolicy")
-	stringattr.Get(m.CookieDomain, data, "domain")
-	boolattr.Get(m.RefreshTokenRotation, data, "rotateJwt")
-	durationattr.Get(m.RefreshTokenExpiration, data, "refreshTokenExpiration")
-	durationattr.Get(m.SessionTokenExpiration, data, "sessionTokenExpiration")
+	stringattr.Get(m.SessionTokenCookiePolicy, data, "sessionTokenCookiePolicy")
+	stringattr.Get(m.SessionTokenCookieDomain, data, "sessionTokenCookieDomain")
 	durationattr.Get(m.StepUpTokenExpiration, data, "stepupTokenExpiration")
 	durationattr.Get(m.TrustedDeviceTokenExpiration, data, "trustedDeviceTokenExpiration")
 	durationattr.Get(m.AccessKeySessionTokenExpiration, data, "keySessionTokenExpiration")
@@ -96,6 +115,15 @@ func (m *SettingsModel) Values(h *helpers.Handler) map[string]any {
 	data["testUserAllowFixedAuth"] = m.TestUsersStaticOTP.ValueString() != ""
 	getJWTTemplate(m.UserJWTTemplate, data, "userTemplateId", "user", h)
 	getJWTTemplate(m.AccessKeyJWTTemplate, data, "keyTemplateId", "key", h)
+
+	// Deprecated
+	if s := m.TokenResponseMethod.ValueString(); s == "cookies" {
+		data["tokenResponseMethod"] = "cookie"
+	} else if s == "response_body" {
+		data["tokenResponseMethod"] = "onBody"
+	}
+	stringattr.Get(m.CookiePolicy, data, "cookiePolicy")
+	stringattr.Get(m.CookieDomain, data, "domain")
 	return data
 }
 
@@ -103,25 +131,33 @@ func (m *SettingsModel) SetValues(h *helpers.Handler, data map[string]any) {
 	stringattr.Set(&m.AppURL, data, "appUrl")
 	stringattr.Set(&m.CustomDomain, data, "customDomain")
 	strlistattr.SetCommaSeparated(&m.ApprovedDomain, data, "trustedDomains")
-	if data["tokenResponseMethod"] == "cookie" {
-		m.RefreshTokenResponseMethod = types.StringValue("cookies")
-	} else if data["tokenResponseMethod"] == "onBody" {
-		m.RefreshTokenResponseMethod = types.StringValue("response_body")
-	} else {
-		h.Error("Unexpected token response method", "Expected value to be either 'cookie' or 'onBody', found: '%v'", data["tokenResponseMethod"])
-	}
-	if data["sessionTokenResponseMethod"] == "cookie" {
-		m.SessionTokenResponseMethod = types.StringValue("cookies")
-	} else if data["sessionTokenResponseMethod"] == "onBody" {
-		m.SessionTokenResponseMethod = types.StringValue("response_body")
-	} else {
-		h.Error("Unexpected session token response method", "Expected value to be either 'cookie' or 'onBody', found: '%v'", data["tokenResponseMethod"])
-	}
-	stringattr.Set(&m.CookiePolicy, data, "cookiePolicy")
-	stringattr.Set(&m.CookieDomain, data, "domain")
 	boolattr.Set(&m.RefreshTokenRotation, data, "rotateJwt")
 	durationattr.Set(&m.RefreshTokenExpiration, data, "refreshTokenExpiration")
+	if helpers.IsImport(h.Ctx) || m.TokenResponseMethod.ValueString() == "" { // can be removed once deprecated attribute is cleaned up
+		if s := data["tokenResponseMethod"]; s == "cookie" {
+			m.RefreshTokenResponseMethod = types.StringValue("cookies")
+		} else if s == "onBody" || s == nil {
+			m.RefreshTokenResponseMethod = types.StringValue("response_body")
+		} else {
+			h.Error("Unexpected refresh token response method", "Expected value to be either 'cookie' or 'onBody', found: '%v'", s)
+		}
+	}
+	if helpers.IsImport(h.Ctx) || m.CookiePolicy.ValueString() == "" { // can be removed once deprecated attribute is cleaned up
+		stringattr.Set(&m.RefreshTokenCookiePolicy, data, "cookiePolicy")
+	}
+	if helpers.IsImport(h.Ctx) || m.CookieDomain.ValueString() == "" { // can be removed once deprecated attribute is cleaned up
+		stringattr.Set(&m.RefreshTokenCookieDomain, data, "domain")
+	}
 	durationattr.Set(&m.SessionTokenExpiration, data, "sessionTokenExpiration")
+	if s := data["sessionTokenResponseMethod"]; s == "cookie" {
+		m.SessionTokenResponseMethod = types.StringValue("cookies")
+	} else if s == "onBody" || s == nil {
+		m.SessionTokenResponseMethod = types.StringValue("response_body")
+	} else {
+		h.Error("Unexpected session token response method", "Expected value to be either 'cookie' or 'onBody', found: '%v'", s)
+	}
+	stringattr.Set(&m.SessionTokenCookiePolicy, data, "sessionTokenCookiePolicy")
+	stringattr.Set(&m.SessionTokenCookieDomain, data, "sessionTokenCookieDomain")
 	durationattr.Set(&m.StepUpTokenExpiration, data, "stepupTokenExpiration")
 	durationattr.Set(&m.TrustedDeviceTokenExpiration, data, "trustedDeviceTokenExpiration")
 	durationattr.Set(&m.AccessKeySessionTokenExpiration, data, "keySessionTokenExpiration")
@@ -136,14 +172,14 @@ func (m *SettingsModel) SetValues(h *helpers.Handler, data map[string]any) {
 	}
 	stringattr.Set(&m.UserJWTTemplate, data, "userTemplateId")
 	stringattr.Set(&m.AccessKeyJWTTemplate, data, "keyTemplateId")
+
+	// Deprecated
+	stringattr.EnsureKnown(&m.TokenResponseMethod)
+	stringattr.EnsureKnown(&m.CookiePolicy)
+	stringattr.EnsureKnown(&m.CookieDomain)
 }
 
 func (m *SettingsModel) Check(h *helpers.Handler) {
-	if m.CookieDomain.ValueString() != "" && m.AppURL.ValueString() == "" { // temporary warning instead of error
-		h.Warn("Missing Attribute Value", "The cookie_domain attribute should be used together with app_url and custom_domain")
-		return
-	}
-
 	appDomain := ""
 	if v := m.AppURL.ValueString(); v != "" {
 		if appURL, err := url.Parse(v); err == nil {
@@ -175,16 +211,32 @@ func (m *SettingsModel) Check(h *helpers.Handler) {
 		customDomain = v
 	}
 
-	if v := m.CookieDomain.ValueString(); v != "" && !strings.HasSuffix(v, ".descope.com") && !strings.HasSuffix(v, ".descope.org") {
-		if customDomain == "" {
-			h.Missing("The cookie_domain attribute requires the custom_domain attribute to be set")
-		} else if v != customDomain && !strings.HasSuffix(customDomain, "."+v) {
-			h.Invalid("The cookie_domain attribute must be set to the same domain as the custom_domain attribute or one of its top level domains")
+	validateCookieDomain := func(value, key string) {
+		if value != "" && !strings.HasSuffix(value, ".descope.com") && !strings.HasSuffix(value, ".descope.org") && !strings.HasSuffix(value, ".descope.app") {
+			if customDomain == "" {
+				h.Missing("The %s attribute requires the custom_domain attribute to be set", key)
+			} else if value != customDomain && !strings.HasSuffix(customDomain, "."+value) {
+				h.Invalid("The %s attribute must be set to the same domain as the custom_domain attribute or one of its top level domains", key)
+			}
 		}
 	}
+	validateCookieDomain(m.RefreshTokenCookieDomain.ValueString(), "refresh_token_cookie_domain")
+	validateCookieDomain(m.SessionTokenCookieDomain.ValueString(), "session_token_cookie_domain")
 
 	if (m.TestUsersStaticOTP.ValueString() == "") != (m.TestUsersVerifierRegExp.ValueString() == "") {
 		h.Invalid("The test_users_static_otp and test_users_verifier_regexp attributes must be set together")
+	}
+}
+
+func (m *SettingsModel) Validate(h *helpers.Handler) {
+	if m.TokenResponseMethod.ValueString() != "" && m.RefreshTokenResponseMethod.ValueString() != "" {
+		h.Error("Conflicting Attribute Value", "Remove the deprecated token_response_method attribute from your configuration and make sure the correct value is set in refresh_token_response_method instead")
+	}
+	if m.CookieDomain.ValueString() != "" && m.RefreshTokenCookieDomain.ValueString() != "" {
+		h.Error("Conflicting Attribute Value", "Remove the deprecated cookie_domain attribute from your configuration and make sure the correct value is set in refresh_token_cookie_domain instead")
+	}
+	if m.CookiePolicy.ValueString() != "" && m.RefreshTokenCookiePolicy.ValueString() != "" {
+		h.Error("Conflicting Attribute Value", "Remove the deprecated cookie_policy attribute from your configuration and make sure the correct value is set in refresh_token_cookie_policy instead")
 	}
 }
 

--- a/internal/models/project/settings/settings_test.go
+++ b/internal/models/project/settings/settings_test.go
@@ -225,7 +225,7 @@ func TestSettings(t *testing.T) {
 		resource.TestStep{
 			Config: p.Config(`
 				project_settings = {
-					cookie_policy = "foo"
+					refresh_token_cookie_policy = "foo"
 				}
 			`),
 			ExpectError: regexp.MustCompile(`value must be one of`),
@@ -233,28 +233,39 @@ func TestSettings(t *testing.T) {
 		resource.TestStep{
 			Config: p.Config(`
 				project_settings = {
-					cookie_domain = "example2.com"
+					cookie_policy = "strict"
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.cookie_domain": "example2.com",
+				"project_settings.cookie_policy": "strict",
 			}),
 		},
 		resource.TestStep{
 			Config: p.Config(`
 				project_settings = {
-					enable_inactivity = true
-					inactivity_time = "1 hour"
-					cookie_policy = "lax"
-					cookie_domain = "example.com"
+					refresh_token_cookie_policy = "lax"
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.refresh_token_expiration": "4 weeks",
-				"project_settings.enable_inactivity":        true,
-				"project_settings.inactivity_time":          "1 hour",
-				"project_settings.cookie_policy":            "lax",
-				"project_settings.cookie_domain":            "example.com",
+				"project_settings.refresh_token_cookie_policy": "lax",
+			}),
+		},
+		resource.TestStep{
+			SkipFunc: testacc.IsLocalEnvironment,
+			Config: p.Config(`
+				project_settings = {
+					enable_inactivity = true
+					inactivity_time = "1 hour"
+					refresh_token_cookie_policy = "lax"
+					refresh_token_cookie_domain = "example.com"
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"project_settings.refresh_token_expiration":    "4 weeks",
+				"project_settings.enable_inactivity":           true,
+				"project_settings.inactivity_time":             "1 hour",
+				"project_settings.refresh_token_cookie_policy": "lax",
+				"project_settings.refresh_token_cookie_domain": "example.com",
 			}),
 		},
 	)

--- a/tools/terragen/conngen/connectors.gotmpl
+++ b/tools/terragen/conngen/connectors.gotmpl
@@ -2,16 +2,13 @@ package connectors
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/listattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers/objectattr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var ConnectorsValidator = objectattr.NewValidator[ConnectorsModel]("must have unique connector names")
@@ -64,9 +61,9 @@ func (m *ConnectorsModel) Validate(h *helpers.Handler) {
 	}
 }
 
-func (m *ConnectorsModel) Modify(ctx context.Context, state *ConnectorsModel, diags *diag.Diagnostics) {
+func (m *ConnectorsModel) Modify(h *helpers.Handler, state *ConnectorsModel, config *ConnectorsModel) {
     {{- range .Connectors }}
-    helpers.MatchModels(ctx, m.{{.StructName}}, state.{{.StructName}})
+    helpers.MatchModels(h.Ctx, m.{{.StructName}}, state.{{.StructName}})
     {{- end }}
 
 	// Upgrade existing identifiers for SMTP connectors to support static IPs
@@ -74,7 +71,7 @@ func (m *ConnectorsModel) Modify(ctx context.Context, state *ConnectorsModel, di
 		id := c.ID.ValueString()
 		if v := strings.TrimPrefix(id, "MP"); v != id && c.UseStaticIPs.ValueBool() {
 			c.ID = types.StringValue("CI" + v)
-			tflog.Info(ctx, fmt.Sprintf("Upgrading identifier for SMTP connector from '%s' to '%s'", id, c.ID.ValueString()))
+			h.Log("Upgrading identifier for SMTP connector from '%s' to '%s'", id, c.ID.ValueString())
 		}
 	}
 }

--- a/tools/testacc/testing.go
+++ b/tools/testacc/testing.go
@@ -1,6 +1,8 @@
 package testacc
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -21,4 +23,9 @@ func TestCase(t *testing.T, steps ...resource.TestStep) resource.TestCase {
 		ProtoV6ProviderFactories: protoV6ProviderFactories,
 		Steps:                    steps,
 	}
+}
+
+func IsLocalEnvironment() (bool, error) {
+	env := os.Getenv("DESCOPE_BASE_URL")
+	return strings.Contains(env, "localhost"), nil
 }


### PR DESCRIPTION

## Description
- Use separate `refresh_token_` attributes to keep backwards compatibility with existing `token_response_method` / `cookie_policy` / `cookie_domain`.
- Add separate cookie settings for session token.

## Must
- [X] Acceptance Tests (passing with latest backend updates)
- [X] Schema Compatibility
- [X] Documentation Updates
