### PR TITLE
Refactor attribute types

### DIFF
--- a/internal/models/helpers/helpers.go
+++ b/internal/models/helpers/helpers.go
@@ -3,6 +3,8 @@ package helpers
 import (
 	"context"
 	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type contextKey string
@@ -38,26 +40,18 @@ func ZVL[T any](o *T, rest ...*T) *T {
 	return &empty
 }
 
-func AnySliceToStringSlice(data map[string]any, key string) []string {
-	var strs []string
-	if objects, ok := data[key].([]any); ok {
-		for _, o := range objects {
-			if s, ok := o.(string); ok {
-				strs = append(strs, s)
+func HasUnknownValues(values ...any) bool {
+	for _, v := range values {
+		switch v := v.(type) {
+		case interface{ IsUnknown() bool }:
+			if v.IsUnknown() {
+				return true
+			}
+		case []types.String:
+			if slices.ContainsFunc(v, func(s types.String) bool { return s.IsUnknown() }) {
+				return true
 			}
 		}
 	}
-	return strs
-}
-
-func EqualStringSliceElements(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for _, v := range a {
-		if !slices.Contains(b, v) {
-			return false
-		}
-	}
-	return true
+	return false
 }

--- a/internal/models/helpers/helpers.go
+++ b/internal/models/helpers/helpers.go
@@ -51,6 +51,12 @@ func HasUnknownValues(values ...any) bool {
 			if slices.ContainsFunc(v, func(s types.String) bool { return s.IsUnknown() }) {
 				return true
 			}
+		case map[string]types.String:
+			for _, s := range v {
+				if s.IsUnknown() {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/internal/models/helpers/strlistattr/strlist.go
+++ b/internal/models/helpers/strlistattr/strlist.go
@@ -28,27 +28,28 @@ func Optional(validators ...validator.List) schema.ListAttribute {
 	}
 }
 
-func Get(s []string, data map[string]any, key string, _ *helpers.Handler) {
-	data[key] = s
+func Get(s []types.String, data map[string]any, key string, _ *helpers.Handler) {
+	data[key] = terraformSliceToStringSlice(s)
 }
 
-func Set(s *[]string, data map[string]any, key string, h *helpers.Handler) {
-	values := helpers.AnySliceToStringSlice(data, key)
+func Set(s *[]types.String, data map[string]any, key string, h *helpers.Handler) {
+	values := anySliceToStringSlice(data, key)
 	if len(*s) > 0 {
-		if !helpers.EqualStringSliceElements(*s, values) {
-			h.Mismatch("Mismatched string array value in '%s' key: received [%s], expected [%s]", key, strings.Join(values, ","), strings.Join(*s, ","))
+		current := terraformSliceToStringSlice(*s)
+		if !equalStringSlicesIgnoringOrder(current, values) {
+			h.Mismatch("Mismatched string array value in '%s' key: received [%s], expected [%s]", key, strings.Join(values, ","), strings.Join(current, ","))
 		}
 		return
 	}
-	*s = values
+	*s = stringSliceToTerraformSlice(values)
 }
 
-func GetCommaSeparated(s []string, data map[string]any, key string) {
-	data[key] = strings.Join(s, ",")
+func GetCommaSeparated(s []types.String, data map[string]any, key string) {
+	data[key] = strings.Join(terraformSliceToStringSlice(s), ",")
 }
 
-func SetCommaSeparated(s *[]string, data map[string]any, key string) {
+func SetCommaSeparated(s *[]types.String, data map[string]any, key string) {
 	if v, _ := data[key].(string); v != "" {
-		*s = strings.Split(v, ",")
+		*s = stringSliceToTerraformSlice(strings.Split(v, ","))
 	}
 }

--- a/internal/models/helpers/strlistattr/utils.go
+++ b/internal/models/helpers/strlistattr/utils.go
@@ -1,0 +1,47 @@
+package strlistattr
+
+import (
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func anySliceToStringSlice(data map[string]any, key string) []string {
+	var strs []string
+	if objects, ok := data[key].([]any); ok {
+		for i := range objects {
+			if s, ok := objects[i].(string); ok {
+				strs = append(strs, s)
+			}
+		}
+	}
+	return strs
+}
+
+func equalStringSlicesIgnoringOrder(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !slices.Contains(b, a[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSliceToTerraformSlice(strs []string) []types.String {
+	var result []types.String
+	for i := range strs {
+		result = append(result, types.StringValue(strs[i]))
+	}
+	return result
+}
+
+func terraformSliceToStringSlice(strs []types.String) []string {
+	var result []string
+	for i := range strs {
+		result = append(result, strs[i].ValueString())
+	}
+	return result
+}

--- a/internal/models/project/applications/oidc.go
+++ b/internal/models/project/applications/oidc.go
@@ -48,5 +48,6 @@ func (m *OIDCModel) SetValues(h *Handler, data map[string]any) {
 	if settings, ok := data["oidc"].(map[string]any); ok {
 		stringattr.Set(&m.LoginPageURL, settings, "loginPageUrl")
 		strlistattr.Set(&m.Claims, settings, "claims", h)
+		boolattr.Set(&m.ForceAuthentication, settings, "forceAuthentication")
 	}
 }

--- a/internal/models/project/applications/oidc.go
+++ b/internal/models/project/applications/oidc.go
@@ -23,14 +23,14 @@ var OIDCAttributes = map[string]schema.Attribute{
 // Model
 
 type OIDCModel struct {
-	ID                  types.String `tfsdk:"id"`
-	Name                types.String `tfsdk:"name"`
-	Description         types.String `tfsdk:"description"`
-	Logo                types.String `tfsdk:"logo"`
-	Disabled            types.Bool   `tfsdk:"disabled"`
-	LoginPageURL        types.String `tfsdk:"login_page_url"`
-	Claims              []string     `tfsdk:"claims"`
-	ForceAuthentication types.Bool   `tfsdk:"force_authentication"`
+	ID                  types.String   `tfsdk:"id"`
+	Name                types.String   `tfsdk:"name"`
+	Description         types.String   `tfsdk:"description"`
+	Logo                types.String   `tfsdk:"logo"`
+	Disabled            types.Bool     `tfsdk:"disabled"`
+	LoginPageURL        types.String   `tfsdk:"login_page_url"`
+	Claims              []types.String `tfsdk:"claims"`
+	ForceAuthentication types.Bool     `tfsdk:"force_authentication"`
 }
 
 func (m *OIDCModel) Values(h *Handler) map[string]any {

--- a/internal/models/project/applications/saml.go
+++ b/internal/models/project/applications/saml.go
@@ -43,7 +43,7 @@ type SAMLModel struct {
 	LoginPageURL           types.String               `tfsdk:"login_page_url"`
 	DynamicConfiguration   *DynamicConfigurationModel `tfsdk:"dynamic_configuration"`
 	ManualConfiguration    *ManualConfigurationModel  `tfsdk:"manual_configuration"`
-	ACSAllowedCallbackURLs []string                   `tfsdk:"acs_allowed_callback_urls"`
+	ACSAllowedCallbackURLs []types.String             `tfsdk:"acs_allowed_callback_urls"`
 	SubjectNameIDType      types.String               `tfsdk:"subject_name_id_type"`
 	SubjectNameIDFormat    types.String               `tfsdk:"subject_name_id_format"`
 	DefaultRelayState      types.String               `tfsdk:"default_relay_state"`
@@ -88,7 +88,7 @@ func (m *SAMLModel) SetValues(h *Handler, data map[string]any) {
 		stringattr.Set(&m.DefaultRelayState, settings, "defaultRelayState")
 		m.AttributeMapping = []*AttributeMappingModel{}
 		listattr.Set(&m.AttributeMapping, settings, "attributeMapping", h)
-		m.ACSAllowedCallbackURLs = []string{}
+		m.ACSAllowedCallbackURLs = []types.String{}
 		strlistattr.Set(&m.ACSAllowedCallbackURLs, settings, "acsAllowedCallbacks", h)
 	}
 }

--- a/internal/models/project/attributes/attributes.go
+++ b/internal/models/project/attributes/attributes.go
@@ -50,7 +50,7 @@ var TenantAttributeAttributes = map[string]schema.Attribute{
 type TenantAttributeModel struct {
 	Name          types.String                       `tfsdk:"name"`
 	Type          types.String                       `tfsdk:"type"`
-	SelectOptions []string                           `tfsdk:"select_options"`
+	SelectOptions []types.String                     `tfsdk:"select_options"`
 	Authorization *TenantAttributeAuthorizationModel `tfsdk:"authorization"`
 }
 
@@ -65,8 +65,8 @@ func (m *TenantAttributeModel) Values(h *helpers.Handler) map[string]any {
 	options := []map[string]any{}
 	for _, o := range m.SelectOptions {
 		options = append(options, map[string]any{
-			"label": o,
-			"value": o,
+			"label": o.ValueString(),
+			"value": o.ValueString(),
 		})
 	}
 	data["options"] = options
@@ -84,7 +84,7 @@ func (m *TenantAttributeModel) SetValues(h *helpers.Handler, data map[string]any
 		for _, v := range vs {
 			if os, ok := v.(map[string]any); ok {
 				if option, ok := os["label"].(string); ok {
-					m.SelectOptions = append(m.SelectOptions, option)
+					m.SelectOptions = append(m.SelectOptions, types.StringValue(option))
 				}
 			}
 		}
@@ -98,7 +98,7 @@ var TenantAttributeAuthorizationAttributes = map[string]schema.Attribute{
 }
 
 type TenantAttributeAuthorizationModel struct {
-	ViewPermissions []string `tfsdk:"view_permissions"`
+	ViewPermissions []types.String `tfsdk:"view_permissions"`
 }
 
 func (m *TenantAttributeAuthorizationModel) Values(h *helpers.Handler) map[string]any {
@@ -172,8 +172,8 @@ var UserAttributeWidgetAuthorizationAttributes = map[string]schema.Attribute{
 }
 
 type UserAttributeAuthorizationModel struct {
-	ViewPermissions []string `tfsdk:"view_permissions"`
-	EditPermissions []string `tfsdk:"edit_permissions"`
+	ViewPermissions []types.String `tfsdk:"view_permissions"`
+	EditPermissions []types.String `tfsdk:"edit_permissions"`
 }
 
 func (m *UserAttributeAuthorizationModel) Values(h *helpers.Handler) map[string]any {
@@ -185,8 +185,8 @@ func (m *UserAttributeAuthorizationModel) Values(h *helpers.Handler) map[string]
 
 func (m *UserAttributeAuthorizationModel) SetValues(h *helpers.Handler, data map[string]any) {
 	if helpers.IsImport(h.Ctx) {
-		m.ViewPermissions = []string{}
-		m.EditPermissions = []string{}
+		m.ViewPermissions = []types.String{}
+		m.EditPermissions = []types.String{}
 	}
 	if m.ViewPermissions != nil {
 		strlistattr.Set(&m.ViewPermissions, data, "viewPermissions", h)

--- a/internal/models/project/authentication/oauth.go
+++ b/internal/models/project/authentication/oauth.go
@@ -270,12 +270,12 @@ type OAuthProviderModel struct {
 	ClientID                types.String                       `tfsdk:"client_id"`
 	ClientSecret            types.String                       `tfsdk:"client_secret"`
 	ProviderTokenManagement *OAuthProviderTokenManagementModel `tfsdk:"provider_token_management"`
-	Prompts                 []string                           `tfsdk:"prompts"`
-	Scopes                  []string                           `tfsdk:"scopes"`
+	Prompts                 []types.String                     `tfsdk:"prompts"`
+	Scopes                  []types.String                     `tfsdk:"scopes"`
 	MergeUserAccounts       types.Bool                         `tfsdk:"merge_user_accounts"`
 	Description             types.String                       `tfsdk:"description"`
 	Logo                    types.String                       `tfsdk:"logo"`
-	AllowedGrantTypes       []string                           `tfsdk:"allowed_grant_types"`
+	AllowedGrantTypes       []types.String                     `tfsdk:"allowed_grant_types"`
 	Issuer                  types.String                       `tfsdk:"issuer"`
 	AuthorizationEndpoint   types.String                       `tfsdk:"authorization_endpoint"`
 	TokenEndpoint           types.String                       `tfsdk:"token_endpoint"`
@@ -340,7 +340,7 @@ func (m *OAuthProviderModel) SetValues(h *helpers.Handler, data map[string]any) 
 		stringattr.Set(&m.ProviderTokenManagement.RedirectURL, data, "redirectUrl")
 	}
 	// Skipped for now: m.Prompts = helpers.AnySliceToStringSlice(data, "prompts")
-	m.Scopes = helpers.AnySliceToStringSlice(data, "scopes")
+	strlistattr.Set(&m.Scopes, data, "scopes", h)
 	boolattr.Set(&m.MergeUserAccounts, data, "trustProvidedEmails")
 	stringattr.Set(&m.Description, data, "description")
 	stringattr.Set(&m.Logo, data, "logo")

--- a/internal/models/project/authentication/oauth.go
+++ b/internal/models/project/authentication/oauth.go
@@ -119,6 +119,8 @@ func ensureRequiredCustomProviderField(h *helpers.Handler, field any, fieldKey, 
 		invalid = v.ValueString() == ""
 	case []string:
 		invalid = len(v) == 0
+	case []types.String:
+		invalid = len(v) == 0
 	default:
 		panic(fmt.Sprintf("unexpected type %T for attribute %s in custom provider %s", field, fieldKey, name))
 	}
@@ -281,7 +283,7 @@ type OAuthProviderModel struct {
 	TokenEndpoint           types.String                       `tfsdk:"token_endpoint"`
 	UserInfoEndpoint        types.String                       `tfsdk:"user_info_endpoint"`
 	JWKsEndpoint            types.String                       `tfsdk:"jwks_endpoint"`
-	ClaimMapping            map[string]string                  `tfsdk:"claim_mapping"`
+	ClaimMapping            map[string]types.String            `tfsdk:"claim_mapping"`
 }
 
 func (m *OAuthProviderModel) Values(h *helpers.Handler) map[string]any {
@@ -318,9 +320,9 @@ func (m *OAuthProviderModel) Values(h *helpers.Handler) map[string]any {
 	customAttributes := map[string]string{}
 	for k, v := range m.ClaimMapping {
 		if slices.Contains(systemClaimMapping, k) {
-			claimMapping[k] = v
+			claimMapping[k] = v.ValueString()
 		} else {
-			customAttributes[k] = v
+			customAttributes[k] = v.ValueString()
 		}
 	}
 	claimMapping["customAttributes"] = customAttributes

--- a/internal/models/project/authentication/oauth.go
+++ b/internal/models/project/authentication/oauth.go
@@ -129,10 +129,10 @@ func ensureRequiredCustomProviderField(h *helpers.Handler, field any, fieldKey, 
 }
 
 func ensureSystemProvider(h *helpers.Handler, m *OAuthProviderModel, name string) {
-	if m == nil {
-		return
+	if m == nil || helpers.HasUnknownValues(m.ClientID, m.ClientSecret) {
+		return // skip validation if there are unknown values
 	}
-	// own account specific validations
+
 	ownAccount := m.ClientID.ValueString() != ""
 	if ownAccount {
 		if m.ClientSecret.ValueString() == "" {

--- a/internal/models/project/authorization/role.go
+++ b/internal/models/project/authorization/role.go
@@ -17,10 +17,10 @@ var RoleAttributes = map[string]schema.Attribute{
 }
 
 type RoleModel struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	Permissions []string     `tfsdk:"permissions"`
+	ID          types.String   `tfsdk:"id"`
+	Name        types.String   `tfsdk:"name"`
+	Description types.String   `tfsdk:"description"`
+	Permissions []types.String `tfsdk:"permissions"`
 }
 
 func (m *RoleModel) Values(h *helpers.Handler) map[string]any {

--- a/internal/models/project/connectors/shared.go
+++ b/internal/models/project/connectors/shared.go
@@ -163,9 +163,9 @@ var AuditFilterFieldAttributes = map[string]schema.Attribute{
 }
 
 type AuditFilterFieldModel struct {
-	Key      types.String `tfsdk:"key"`
-	Operator types.String `tfsdk:"operator"`
-	Vals     []string     `tfsdk:"values"`
+	Key      types.String   `tfsdk:"key"`
+	Operator types.String   `tfsdk:"operator"`
+	Vals     []types.String `tfsdk:"values"`
 }
 
 func (m *AuditFilterFieldModel) Values(h *helpers.Handler) map[string]any {

--- a/internal/models/project/connectors/shared.go
+++ b/internal/models/project/connectors/shared.go
@@ -248,6 +248,10 @@ func (m *HTTPAuthFieldModel) SetValues(h *helpers.Handler, data map[string]any) 
 }
 
 func (m *HTTPAuthFieldModel) Validate(h *helpers.Handler) {
+	if helpers.HasUnknownValues(m.BearerToken) {
+		return // skip validation if there are unknown values
+	}
+
 	count := 0
 	if m.BearerToken.ValueString() != "" {
 		count += 1

--- a/internal/models/project/connectors/twiliocore.go
+++ b/internal/models/project/connectors/twiliocore.go
@@ -127,6 +127,9 @@ func (m *TwilioCoreSendersFieldModel) SetValues(h *helpers.Handler, data map[str
 
 func (m *TwilioCoreSendersFieldModel) Validate(h *helpers.Handler) {
 	if v := m.SMS; v != nil {
+		if helpers.HasUnknownValues(v.PhoneNumber, v.MessagingServiceSID) {
+			return // skip validation if there are unknown values
+		}
 		if m.SMS.PhoneNumber.ValueString() == "" && m.SMS.MessagingServiceSID.ValueString() == "" {
 			h.Missing("The Twilio Core connector SMS sender requires either the phone_number or messaging_service_sid attribute to be set")
 		}
@@ -172,6 +175,9 @@ func (m *TwilioAuthFieldModel) SetValues(h *helpers.Handler, data map[string]any
 }
 
 func (m *TwilioAuthFieldModel) Validate(h *helpers.Handler) {
+	if helpers.HasUnknownValues(m.AuthToken, m.APIKey, m.APISecret) {
+		return // skip validation if there are unknown values
+	}
 	if m.AuthToken.ValueString() == "" && (m.APIKey.ValueString() == "" && m.APISecret.ValueString() == "") {
 		h.Missing("The Twilio Core connector requires an authentication method to be set")
 	}

--- a/internal/models/project/flows/styles.go
+++ b/internal/models/project/flows/styles.go
@@ -40,8 +40,8 @@ func (m *StylesModel) SetValues(h *helpers.Handler, data map[string]any) {
 }
 
 func (m *StylesModel) Validate(h *helpers.Handler) {
-	if m.Data.IsUnknown() {
-		return
+	if helpers.HasUnknownValues(m.Data) {
+		return // skip validation if there are unknown values//
 	}
 	data := getStylesData(m.Data, h)
 	if data["styles"] == nil {

--- a/internal/models/project/project.go
+++ b/internal/models/project/project.go
@@ -44,7 +44,7 @@ type ProjectModel struct {
 	ID             types.String                        `tfsdk:"id"`
 	Name           types.String                        `tfsdk:"name"`
 	Environment    types.String                        `tfsdk:"environment"`
-	Tags           []string                            `tfsdk:"tags"`
+	Tags           []types.String                      `tfsdk:"tags"`
 	Settings       *settings.SettingsModel             `tfsdk:"project_settings"`
 	Invite         *settings.InviteSettingsModel       `tfsdk:"invite_settings"`
 	Authentication *authentication.AuthenticationModel `tfsdk:"authentication"`

--- a/internal/models/project/settings/settings.go
+++ b/internal/models/project/settings/settings.go
@@ -48,28 +48,28 @@ var SettingsAttributes = map[string]schema.Attribute{
 }
 
 type SettingsModel struct {
-	AppURL                          types.String `tfsdk:"app_url"`
-	CustomDomain                    types.String `tfsdk:"custom_domain"`
-	ApprovedDomain                  []string     `tfsdk:"approved_domains"`
-	RefreshTokenRotation            types.Bool   `tfsdk:"refresh_token_rotation"`
-	RefreshTokenExpiration          types.String `tfsdk:"refresh_token_expiration"`
-	RefreshTokenResponseMethod      types.String `tfsdk:"refresh_token_response_method"`
-	RefreshTokenCookiePolicy        types.String `tfsdk:"refresh_token_cookie_policy"`
-	RefreshTokenCookieDomain        types.String `tfsdk:"refresh_token_cookie_domain"`
-	SessionTokenExpiration          types.String `tfsdk:"session_token_expiration"`
-	SessionTokenResponseMethod      types.String `tfsdk:"session_token_response_method"`
-	SessionTokenCookiePolicy        types.String `tfsdk:"session_token_cookie_policy"`
-	SessionTokenCookieDomain        types.String `tfsdk:"session_token_cookie_domain"`
-	StepUpTokenExpiration           types.String `tfsdk:"step_up_token_expiration"`
-	TrustedDeviceTokenExpiration    types.String `tfsdk:"trusted_device_token_expiration"`
-	AccessKeySessionTokenExpiration types.String `tfsdk:"access_key_session_token_expiration"`
-	EnableInactivity                types.Bool   `tfsdk:"enable_inactivity"`
-	InactivityTime                  types.String `tfsdk:"inactivity_time"`
-	TestUsersLoginIDRegExp          types.String `tfsdk:"test_users_loginid_regexp"`
-	TestUsersVerifierRegExp         types.String `tfsdk:"test_users_verifier_regexp"`
-	TestUsersStaticOTP              types.String `tfsdk:"test_users_static_otp"`
-	UserJWTTemplate                 types.String `tfsdk:"user_jwt_template"`
-	AccessKeyJWTTemplate            types.String `tfsdk:"access_key_jwt_template"`
+	AppURL                          types.String   `tfsdk:"app_url"`
+	CustomDomain                    types.String   `tfsdk:"custom_domain"`
+	ApprovedDomain                  []types.String `tfsdk:"approved_domains"`
+	RefreshTokenRotation            types.Bool     `tfsdk:"refresh_token_rotation"`
+	RefreshTokenExpiration          types.String   `tfsdk:"refresh_token_expiration"`
+	RefreshTokenResponseMethod      types.String   `tfsdk:"refresh_token_response_method"`
+	RefreshTokenCookiePolicy        types.String   `tfsdk:"refresh_token_cookie_policy"`
+	RefreshTokenCookieDomain        types.String   `tfsdk:"refresh_token_cookie_domain"`
+	SessionTokenExpiration          types.String   `tfsdk:"session_token_expiration"`
+	SessionTokenResponseMethod      types.String   `tfsdk:"session_token_response_method"`
+	SessionTokenCookiePolicy        types.String   `tfsdk:"session_token_cookie_policy"`
+	SessionTokenCookieDomain        types.String   `tfsdk:"session_token_cookie_domain"`
+	StepUpTokenExpiration           types.String   `tfsdk:"step_up_token_expiration"`
+	TrustedDeviceTokenExpiration    types.String   `tfsdk:"trusted_device_token_expiration"`
+	AccessKeySessionTokenExpiration types.String   `tfsdk:"access_key_session_token_expiration"`
+	EnableInactivity                types.Bool     `tfsdk:"enable_inactivity"`
+	InactivityTime                  types.String   `tfsdk:"inactivity_time"`
+	TestUsersLoginIDRegExp          types.String   `tfsdk:"test_users_loginid_regexp"`
+	TestUsersVerifierRegExp         types.String   `tfsdk:"test_users_verifier_regexp"`
+	TestUsersStaticOTP              types.String   `tfsdk:"test_users_static_otp"`
+	UserJWTTemplate                 types.String   `tfsdk:"user_jwt_template"`
+	AccessKeyJWTTemplate            types.String   `tfsdk:"access_key_jwt_template"`
 
 	// Deprecated
 	TokenResponseMethod types.String `tfsdk:"token_response_method"`

--- a/internal/models/project/templates/emailtemplate.go
+++ b/internal/models/project/templates/emailtemplate.go
@@ -54,15 +54,18 @@ func (m *EmailTemplateModel) SetValues(h *helpers.Handler, data map[string]any) 
 }
 
 func (m *EmailTemplateModel) Validate(h *helpers.Handler) {
+	if helpers.HasUnknownValues(m.Name, m.UsePlainTextBody, m.PlainTextBody, m.HTMLBody) {
+		return // skip validation if there are unknown values
+	}
 	if m.Name.ValueString() == helpers.DescopeTemplate || m.ID.ValueString() == helpers.DescopeTemplate {
 		h.Error("Invalid email template", "Cannot use 'System' as the name or id of a template")
 	}
 	if m.UsePlainTextBody.ValueBool() {
-		if m.PlainTextBody.ValueString() == "" && !m.PlainTextBody.IsUnknown() {
+		if m.PlainTextBody.ValueString() == "" {
 			h.Missing("The plain_text_body attribute is required when use_plain_text_body is enabled")
 		}
 	} else {
-		if m.HTMLBody.ValueString() == "" && !m.HTMLBody.IsUnknown() {
+		if m.HTMLBody.ValueString() == "" {
 			h.Missing("The html_body attribute is required unless use_plain_text_body is enabled")
 		}
 	}


### PR DESCRIPTION
## Description
- Use `[]types.String` for `list` attributes to support dynamic values
- Add missing field setter for OIDC apps
- Update validation functions for objects to skip when encountering `unknown` values
- Use `types.String` in `map` attributes to support dynamic values

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
