### PR TITLE
Don't show redundant error message when existing templates in the Terraform state file are removed from the backend

### DIFF
--- a/internal/models/project/templates/emailservice.go
+++ b/internal/models/project/templates/emailservice.go
@@ -48,6 +48,8 @@ func (m *EmailServiceModel) SetValues(h *helpers.Handler, data map[string]any) {
 			} else {
 				h.Log("Keeping existing ID '%s' for email template named '%s'", id, name)
 			}
+		} else if template.ID.ValueString() == "" {
+			h.Error("Template not found", "Expected to find email template to match with '%s' template", name)
 		}
 	}
 	// we allow to set templates on import

--- a/internal/models/project/templates/shared.go
+++ b/internal/models/project/templates/shared.go
@@ -24,7 +24,7 @@ func requireTemplateID(h *helpers.Handler, data map[string]any, typ string, name
 		}
 	}
 
-	h.Error("Template not found", "Expected to find template in '%s' to match with '%s' template", typ, name)
+	h.Log("Expected to find template in '%s' to match with '%s' template, this could be due to a state file mismatch", typ, name)
 	return "", false
 }
 

--- a/internal/models/project/templates/textservice.go
+++ b/internal/models/project/templates/textservice.go
@@ -48,6 +48,8 @@ func (m *TextServiceModel) SetValues(h *helpers.Handler, data map[string]any) {
 			} else {
 				h.Log("Keeping existing ID '%s' for text template named '%s'", id, name)
 			}
+		} else if template.ID.ValueString() == "" {
+			h.Error("Template not found", "Expected to find text template to match with '%s' template", name)
 		}
 	}
 	// we allow to set templates on import

--- a/internal/models/project/templates/voiceservice.go
+++ b/internal/models/project/templates/voiceservice.go
@@ -48,6 +48,8 @@ func (m *VoiceServiceModel) SetValues(h *helpers.Handler, data map[string]any) {
 			} else {
 				h.Log("Keeping existing ID '%s' for voice template named '%s'", id, name)
 			}
+		} else if template.ID.ValueString() == "" {
+			h.Error("Template not found", "Expected to find voice template to match with '%s' template", name)
 		}
 	}
 	// we allow to set templates on import


### PR DESCRIPTION
## Description
- Don't show redundant error message when existing templates in the Terraform state file are removed from the backend

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
