### PR TITLE
Fix object validation issue and session_migration attribute handling

### DIFF
--- a/internal/models/attrs/durationattr/validators.go
+++ b/internal/models/attrs/durationattr/validators.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func MinimumValue(duration string) validator.String {
@@ -28,6 +29,7 @@ func (v durationValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v durationValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	tflog.Trace(ctx, "Validating duration", map[string]any{"path": request.Path.String()})
 	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/models/attrs/objattr/validators.go
+++ b/internal/models/attrs/objattr/validators.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func NewValidator[T any, M validatableModel[T]](description string) validator.Object {
@@ -33,7 +34,8 @@ func (v *objectValidator[T, M]) MarkdownDescription(ctx context.Context) string 
 }
 
 func (v *objectValidator[T, M]) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
-	if req.ConfigValue.IsNull() {
+	tflog.Debug(ctx, "Validating object", map[string]any{"path": req.Path.String()})
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 

--- a/internal/models/attrs/stringattr/validators.go
+++ b/internal/models/attrs/stringattr/validators.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var TimeUnitValidator = stringvalidator.OneOf("seconds", "minutes", "hours", "days", "weeks")
@@ -39,6 +40,7 @@ func (v nonEmptyValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v nonEmptyValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	tflog.Trace(ctx, "Validating string", map[string]any{"path": req.Path.String()})
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
@@ -64,6 +66,7 @@ func (v jsonValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v jsonValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	tflog.Trace(ctx, "Validating string", map[string]any{"path": req.Path.String()})
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/models/project/settings/migration.go
+++ b/internal/models/project/settings/migration.go
@@ -5,19 +5,18 @@ import (
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/strsetattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 var SessionMigrationValidator = objattr.NewValidator[SessionMigrationModel]("must have a valid configuration")
 
 var SessionMigrationAttributes = map[string]schema.Attribute{
-	"vendor":                     stringattr.Required(stringattr.StandardLenValidator),
-	"client_id":                  stringattr.Required(stringattr.StandardLenValidator),
+	"vendor":                     stringattr.Default("", stringattr.StandardLenValidator),
+	"client_id":                  stringattr.Default("", stringattr.StandardLenValidator),
 	"domain":                     stringattr.Default("", stringattr.StandardLenValidator),
 	"audience":                   stringattr.Default("", stringattr.StandardLenValidator),
 	"issuer":                     stringattr.Default("", stringattr.StandardLenValidator),
-	"loginid_matched_attributes": strsetattr.Required(setvalidator.SizeAtLeast(1), stringattr.StandardLenValidator),
+	"loginid_matched_attributes": strsetattr.Default(stringattr.StandardLenValidator),
 }
 
 type SessionMigrationModel struct {
@@ -29,15 +28,25 @@ type SessionMigrationModel struct {
 	LoginIDMatchedAttributes strsetattr.Type `tfsdk:"loginid_matched_attributes"`
 }
 
+var SessionMigrationDefaujlt = &SessionMigrationModel{
+	Vendor:                   stringattr.Value(""),
+	ClientID:                 stringattr.Value(""),
+	Domain:                   stringattr.Value(""),
+	Audience:                 stringattr.Value(""),
+	Issuer:                   stringattr.Value(""),
+	LoginIDMatchedAttributes: strsetattr.Empty(),
+}
+
 func (m *SessionMigrationModel) Values(h *helpers.Handler) map[string]any {
 	vendor := m.Vendor.ValueString()
 
 	c := map[string]any{}
 	stringattr.Get(m.ClientID, c, "clientId")
-	if vendor == "auth0" {
+	switch vendor {
+	case "auth0":
 		stringattr.Get(m.Domain, c, "domain")
 		stringattr.Get(m.Audience, c, "audience")
-	} else if vendor == "okta" {
+	case "okta":
 		stringattr.Get(m.Issuer, c, "issuer")
 	}
 
@@ -61,18 +70,28 @@ func (m *SessionMigrationModel) SetValues(h *helpers.Handler, data map[string]an
 		stringattr.Nil(&m.Audience)
 		stringattr.Set(&m.Issuer, v, "issuer")
 	} else {
-		h.Error("Unexpected session migration vendor", "Expected to find a valid configuration key")
+		m.Vendor = stringattr.Value("")
+		stringattr.Nil(&m.ClientID)
+		stringattr.Nil(&m.Domain)
+		stringattr.Nil(&m.Audience)
+		stringattr.Nil(&m.Issuer)
 	}
 	strsetattr.Set(&m.LoginIDMatchedAttributes, data, "loginIdExternalUserSources", h)
 }
 
 func (m *SessionMigrationModel) Validate(h *helpers.Handler) {
-	if helpers.HasUnknownValues(m.Vendor, m.Domain, m.Audience, m.Issuer) {
+	if helpers.HasUnknownValues(m.Vendor, m.ClientID, m.Domain, m.Audience, m.Issuer, m.LoginIDMatchedAttributes) {
 		return
 	}
 
 	vendor := m.Vendor.ValueString()
+
 	switch vendor {
+	case "":
+		if m.ClientID.ValueString() != "" || m.Domain.ValueString() != "" || m.Audience.ValueString() != "" || m.Issuer.ValueString() != "" || !m.LoginIDMatchedAttributes.IsEmpty() {
+			h.Invalid("The other session_migration attributes must not be set when vendor is not specified")
+		}
+		return
 	case "auth0":
 		if m.Domain.ValueString() == "" {
 			h.Missing("The domain attribute is required for %s session migration", vendor)
@@ -92,5 +111,12 @@ func (m *SessionMigrationModel) Validate(h *helpers.Handler) {
 		}
 	default:
 		h.Invalid("Unsupported session migration vendor: %s", vendor)
+	}
+
+	if m.ClientID.ValueString() == "" {
+		h.Missing("The client_id attribute is required for %s session migration", vendor)
+	}
+	if m.LoginIDMatchedAttributes.IsEmpty() {
+		h.Missing("The loginid_matched_attributes attribute is expected to be a non-empty list for %s session migration", vendor)
 	}
 }

--- a/internal/models/project/settings/migration.go
+++ b/internal/models/project/settings/migration.go
@@ -28,7 +28,7 @@ type SessionMigrationModel struct {
 	LoginIDMatchedAttributes strsetattr.Type `tfsdk:"loginid_matched_attributes"`
 }
 
-var SessionMigrationDefaujlt = &SessionMigrationModel{
+var SessionMigrationDefault = &SessionMigrationModel{
 	Vendor:                   stringattr.Value(""),
 	ClientID:                 stringattr.Value(""),
 	Domain:                   stringattr.Value(""),

--- a/internal/models/project/settings/settings.go
+++ b/internal/models/project/settings/settings.go
@@ -40,7 +40,7 @@ var SettingsAttributes = map[string]schema.Attribute{
 	"test_users_static_otp":               stringattr.Default("", stringattr.OTPValidator),
 	"user_jwt_template":                   stringattr.Default(""),
 	"access_key_jwt_template":             stringattr.Default(""),
-	"session_migration":                   objattr.Default[SessionMigrationModel](nil, SessionMigrationAttributes, SessionMigrationValidator),
+	"session_migration":                   objattr.Default(SessionMigrationDefaujlt, SessionMigrationAttributes, SessionMigrationValidator),
 }
 
 type SettingsModel struct {
@@ -108,7 +108,11 @@ func (m *SettingsModel) Values(h *helpers.Handler) map[string]any {
 	data["testUserAllowFixedAuth"] = m.TestUsersStaticOTP.ValueString() != ""
 	getJWTTemplate(m.UserJWTTemplate, data, "userTemplateId", "user", h)
 	getJWTTemplate(m.AccessKeyJWTTemplate, data, "keyTemplateId", "key", h)
-	objattr.Get(m.SessionMigration, data, "externalAuthConfig", h)
+	if v, _ := m.SessionMigration.ToObject(h.Ctx); v != nil && v.Vendor.ValueString() != "" {
+		objattr.Get(m.SessionMigration, data, "externalAuthConfig", h)
+	} else {
+		data["externalAuthConfig"] = nil
+	}
 	return data
 }
 
@@ -152,7 +156,9 @@ func (m *SettingsModel) SetValues(h *helpers.Handler, data map[string]any) {
 	}
 	stringattr.Set(&m.UserJWTTemplate, data, "userTemplateId")     // replaced by template name by UpdateReferences later
 	stringattr.Set(&m.AccessKeyJWTTemplate, data, "keyTemplateId") // replaced by template name by UpdateReferences later
-	objattr.Set(&m.SessionMigration, data, "externalAuthConfig", h)
+	if data["externalAuthConfig"] != nil {                         // server returns no object if not set
+		objattr.Set(&m.SessionMigration, data, "externalAuthConfig", h)
+	}
 }
 
 func (m *SettingsModel) Validate(h *helpers.Handler) {

--- a/internal/models/project/settings/settings.go
+++ b/internal/models/project/settings/settings.go
@@ -40,7 +40,7 @@ var SettingsAttributes = map[string]schema.Attribute{
 	"test_users_static_otp":               stringattr.Default("", stringattr.OTPValidator),
 	"user_jwt_template":                   stringattr.Default(""),
 	"access_key_jwt_template":             stringattr.Default(""),
-	"session_migration":                   objattr.Default(SessionMigrationDefaujlt, SessionMigrationAttributes, SessionMigrationValidator),
+	"session_migration":                   objattr.Default(SessionMigrationDefault, SessionMigrationAttributes, SessionMigrationValidator),
 }
 
 type SettingsModel struct {

--- a/internal/models/project/settings/settings_test.go
+++ b/internal/models/project/settings/settings_test.go
@@ -297,10 +297,12 @@ func TestSettings(t *testing.T) {
 		resource.TestStep{
 			Config: p.Config(`
 				project_settings = {
-					session_migration = {}
+					session_migration = {
+						vendor = "foo"
+					}
 				}
 			`),
-			ExpectError: regexp.MustCompile(`Inappropriate value`),
+			ExpectError: regexp.MustCompile(`Invalid Attribute Value`),
 		},
 		resource.TestStep{
 			Config: p.Config(`
@@ -345,7 +347,14 @@ func TestSettings(t *testing.T) {
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"project_settings.session_migration.%": 0,
+				"project_settings.session_migration": map[string]any{
+					"vendor":                     "",
+					"client_id":                  "",
+					"domain":                     "",
+					"audience":                   "",
+					"issuer":                     "",
+					"loginid_matched_attributes": []string{},
+				},
 			}),
 		},
 	)


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/11433

## Description
- Fix bug with validating objects which caused failures when the value of the object was `unknown`.
- Improve handling of `session_migration` object to ensure it is read properly.
- Allow disabling `session_migration` by setting an object with a `vendor` attribute that's set to an empty string.

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
