### PR TITLE
Add a new --add-connectors flag to terragen

### DIFF
--- a/tools/terragen/conngen/naming.go
+++ b/tools/terragen/conngen/naming.go
@@ -36,6 +36,9 @@ func (n *Naming) GetName(category, id, kind, fallback string) string {
 	}
 	idNames, ok := categoryNames[id]
 	if !ok {
+		if category == "connector" && kind == "file" && !utils.Flags.AddConnectors {
+			return fallback
+		}
 		idNames = map[string]string{}
 		categoryNames[id] = idNames
 	}

--- a/tools/terragen/conngen/parse.go
+++ b/tools/terragen/conngen/parse.go
@@ -14,9 +14,7 @@ func ParseConnectors(datadir string, templatesdir string) *Connectors {
 		Naming: &Naming{},
 	}
 
-	if !utils.Flags.SkipTemplates {
-		conns.Read(datadir, templatesdir)
-	}
+	conns.Read(datadir, templatesdir)
 
 	conns.Naming.Read(datadir)
 

--- a/tools/terragen/main.go
+++ b/tools/terragen/main.go
@@ -15,10 +15,13 @@ func main() {
 	// ensures that required paths are available and creates directories for generated files
 	paths := utils.PreparePaths()
 
-	// parses all connector template metadata (unless --skip-templates flag was set)
+	// parses all connector template metadata
 	conns := conngen.ParseConnectors(paths.Data, paths.Templates)
 
-	// generates .go sources and tests for all connector models (unless --skip-templates flag was set)
+	// remove any connectors from the templates that don't already exist (unless --add-connectors flag was set)
+	conngen.TrimConnectors(paths.Connectors, conns)
+
+	// generates .go sources and tests for all connector models
 	conngen.GenerateSources(paths.Connectors, conns)
 
 	// creates a simple schema representation by parsing attributes in all model .go source files

--- a/tools/terragen/utils/flags.go
+++ b/tools/terragen/utils/flags.go
@@ -5,12 +5,12 @@ import "flag"
 var Flags = struct {
 	Verbose       bool
 	SkipValidate  bool
-	SkipTemplates bool
+	AddConnectors bool
 }{}
 
 func ParseFlags() {
 	flag.BoolVar(&Flags.Verbose, "verbose", false, "set to true to print verbose logs")
 	flag.BoolVar(&Flags.SkipValidate, "skip-validate", false, "set to true to not fail on validation errors")
-	flag.BoolVar(&Flags.SkipTemplates, "skip-templates", false, "set to true to skip parsing templates")
+	flag.BoolVar(&Flags.AddConnectors, "add-connectors", false, "set to true to add new connectors from the templates")
 	flag.Parse()
 }

--- a/tools/terragen/utils/paths.go
+++ b/tools/terragen/utils/paths.go
@@ -41,16 +41,13 @@ func PreparePaths() *Paths {
 
 	data := filepath.Join(root, "tools", "terragen", "conngen")
 
-	templates := ""
-	if !Flags.SkipTemplates {
-		templates = strings.TrimSpace(os.Getenv("DESCOPE_TEMPLATES_PATH"))
-		if templates == "" {
-			log.Fatalf("expected path to templates in DESCOPE_TEMPLATES_PATH environment variable")
-		}
-		templates = filepath.Clean(templates)
-		if info, err := os.Stat(templates); os.IsNotExist(err) || !info.IsDir() {
-			log.Fatalf("expected to find templates directory at path: %s", templates)
-		}
+	templates := strings.TrimSpace(os.Getenv("DESCOPE_TEMPLATES_PATH"))
+	if templates == "" {
+		log.Fatalf("expected path to templates in DESCOPE_TEMPLATES_PATH environment variable")
+	}
+	templates = filepath.Clean(templates)
+	if info, err := os.Stat(templates); os.IsNotExist(err) || !info.IsDir() {
+		log.Fatalf("expected to find templates directory at path: %s", templates)
 	}
 
 	return &Paths{


### PR DESCRIPTION
## Description
Add a new optional `--add-connectors` flag to `terragen`. The default behavior when running `make terragen` now is not to add new connectors from the templates, only to update the documentation and definitions for existing models and connectors.

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
