### PR TITLE
Add SSO Suite customization and visibility options

### DIFF
--- a/docs/raw/project/authentication/sso.md
+++ b/docs/raw/project/authentication/sso.md
@@ -96,7 +96,7 @@ hide_saml
 
 
 Setting this to `true` will hide the SAML configuration option.
-Note: At least one of SAML or OIDC must remain enabled for SSO functionality.
+Note: At least one of SAML or OIDC must remain enabled.
 
 
 
@@ -107,4 +107,4 @@ hide_oidc
 
 
 Setting this to `true` will hide the OIDC configuration option.
-Note: At least one of SAML or OIDC must remain enabled for SSO functionality.
+Note: At least one of SAML or OIDC must remain enabled.

--- a/docs/raw/project/authentication/sso.md
+++ b/docs/raw/project/authentication/sso.md
@@ -31,3 +31,59 @@ redirect_url
 
 The URL the end user is redirected to after a successful authentication. If one is specified
 in tenant level settings or SDK/API call, they will override this value.
+
+
+
+sso_suite_style_id
+------------
+
+- Type: `string` 
+
+Specifies the style ID to apply in the SSO Suite. Ensure a style with this ID exists in the console for it to be used.
+
+
+
+hide_sso_suite_scim
+------------
+
+- Type: `bool` 
+
+Setting this to `true` will hide the SCIM configuration in the SSO Suite interface.
+
+
+
+hide_sso_suite_groups_mapping
+------------
+
+- Type: `bool` 
+
+Setting this to `true` will hide the groups mapping configuration section in the SSO Suite interface.
+
+
+
+hide_sso_suite_domains
+------------
+
+- Type: `bool` 
+
+Setting this to `true` will hide the domains configuration section in the SSO Suite interface.
+
+
+
+hide_sso_suite_saml
+------------
+
+- Type: `bool` 
+
+Setting this to `true` will hide the SAML configuration option.
+Note: At least one of SAML or OIDC must remain enabled for SSO functionality.
+
+
+
+hide_sso_suite_oidc
+------------
+
+- Type: `bool` 
+
+Setting this to `true` will hide the OIDC configuration option.
+Note: At least one of SAML or OIDC must remain enabled for SSO functionality.

--- a/docs/raw/project/authentication/sso.md
+++ b/docs/raw/project/authentication/sso.md
@@ -34,56 +34,77 @@ in tenant level settings or SDK/API call, they will override this value.
 
 
 
-sso_suite_style_id
-------------
+sso_suite_settings
+------------------
+
+- Type: `object` of `authentication.SSOSuite` 
+
+sso_suite_settings: Configuration block for the SSO Suite. 
+
+
+
+
+SSOSuite
+========
+
+
+
+style_id
+--------
 
 - Type: `string` 
+
 
 Specifies the style ID to apply in the SSO Suite. Ensure a style with this ID exists in the console for it to be used.
 
 
 
-hide_sso_suite_scim
-------------
+hide_scim
+---------
 
 - Type: `bool` 
+
 
 Setting this to `true` will hide the SCIM configuration in the SSO Suite interface.
 
 
 
-hide_sso_suite_groups_mapping
-------------
+hide_groups_mapping
+-------------------
 
 - Type: `bool` 
+
 
 Setting this to `true` will hide the groups mapping configuration section in the SSO Suite interface.
 
 
 
-hide_sso_suite_domains
+hide_domains
 ------------
 
 - Type: `bool` 
+
 
 Setting this to `true` will hide the domains configuration section in the SSO Suite interface.
 
 
 
-hide_sso_suite_saml
-------------
+hide_saml
+---------
 
 - Type: `bool` 
+
 
 Setting this to `true` will hide the SAML configuration option.
 Note: At least one of SAML or OIDC must remain enabled for SSO functionality.
 
 
 
-hide_sso_suite_oidc
-------------
+hide_oidc
+---------
 
 - Type: `bool` 
+
 
 Setting this to `true` will hide the OIDC configuration option.
 Note: At least one of SAML or OIDC must remain enabled for SSO functionality.

--- a/docs/raw/project/authentication/sso.md
+++ b/docs/raw/project/authentication/sso.md
@@ -39,7 +39,8 @@ sso_suite_settings
 
 - Type: `object` of `authentication.SSOSuite` 
 
-sso_suite_settings: Configuration block for the SSO Suite. 
+Configuration block for the SSO Suite.
+
 
 
 
@@ -54,8 +55,8 @@ style_id
 
 - Type: `string` 
 
-
-Specifies the style ID to apply in the SSO Suite. Ensure a style with this ID exists in the console for it to be used.
+Specifies the style ID to apply in the SSO Suite. Ensure a style with this ID exists in
+the console for it to be used.
 
 
 
@@ -63,7 +64,6 @@ hide_scim
 ---------
 
 - Type: `bool` 
-
 
 Setting this to `true` will hide the SCIM configuration in the SSO Suite interface.
 
@@ -74,7 +74,6 @@ hide_groups_mapping
 
 - Type: `bool` 
 
-
 Setting this to `true` will hide the groups mapping configuration section in the SSO Suite interface.
 
 
@@ -83,7 +82,6 @@ hide_domains
 ------------
 
 - Type: `bool` 
-
 
 Setting this to `true` will hide the domains configuration section in the SSO Suite interface.
 
@@ -94,9 +92,7 @@ hide_saml
 
 - Type: `bool` 
 
-
 Setting this to `true` will hide the SAML configuration option.
-Note: At least one of SAML or OIDC must remain enabled.
 
 
 
@@ -105,6 +101,4 @@ hide_oidc
 
 - Type: `bool` 
 
-
 Setting this to `true` will hide the OIDC configuration option.
-Note: At least one of SAML or OIDC must remain enabled.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -810,6 +810,20 @@ Optional:
 - `disabled` (Boolean) Setting this to `true` will disallow using this authentication method directly via API and SDK calls. Note that this does not affect authentication flows that are configured to use this authentication method.
 - `merge_users` (Boolean) Whether to merge existing user accounts with new ones created through SSO authentication.
 - `redirect_url` (String) The URL the end user is redirected to after a successful authentication. If one is specified in tenant level settings or SDK/API call, they will override this value.
+- `sso_suite_settings` (Attributes) Configuration block for the SSO Suite. (see [below for nested schema](#nestedatt--authentication--sso--sso_suite_settings))
+
+<a id="nestedatt--authentication--sso--sso_suite_settings"></a>
+### Nested Schema for `authentication.sso.sso_suite_settings`
+
+Optional:
+
+- `hide_domains` (Boolean) Setting this to `true` will hide the domains configuration section in the SSO Suite interface.
+- `hide_groups_mapping` (Boolean) Setting this to `true` will hide the groups mapping configuration section in the SSO Suite interface.
+- `hide_oidc` (Boolean) Setting this to `true` will hide the OIDC configuration option.
+- `hide_saml` (Boolean) Setting this to `true` will hide the SAML configuration option.
+- `hide_scim` (Boolean) Setting this to `true` will hide the SCIM configuration in the SSO Suite interface.
+- `style_id` (String) Specifies the style ID to apply in the SSO Suite. Ensure a style with this ID exists in the console for it to be used.
+
 
 
 <a id="nestedatt--authentication--totp"></a>

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -235,6 +235,17 @@ var docsSSO = map[string]string{
 	"merge_users": "Whether to merge existing user accounts with new ones created through SSO authentication.",
 	"redirect_url": "The URL the end user is redirected to after a successful authentication. If one is specified " +
 	                "in tenant level settings or SDK/API call, they will override this value.",
+	"sso_suite_settings": "Configuration block for the SSO Suite.",
+}
+
+var docsSSOSuite = map[string]string{
+	"style_id": "Specifies the style ID to apply in the SSO Suite. Ensure a style with this ID exists in " +
+	            "the console for it to be used.",
+	"hide_scim": "Setting this to `true` will hide the SCIM configuration in the SSO Suite interface.",
+	"hide_groups_mapping": "Setting this to `true` will hide the groups mapping configuration section in the SSO Suite interface.",
+	"hide_domains": "Setting this to `true` will hide the domains configuration section in the SSO Suite interface.",
+	"hide_saml": "Setting this to `true` will hide the SAML configuration option.",
+	"hide_oidc": "Setting this to `true` will hide the OIDC configuration option.",
 }
 
 var docsTOTP = map[string]string{

--- a/internal/docs/models.go
+++ b/internal/docs/models.go
@@ -42,6 +42,7 @@ func InjectModels() {
 	inject(authentication.PasskeysAttributes, docsPasskeys)
 	inject(authentication.PasswordAttributes, docsPassword)
 	inject(authentication.SSOAttributes, docsSSO)
+	inject(authentication.SSOSuiteAttributes, docsSSOSuite)
 	inject(authentication.TOTPAttributes, docsTOTP)
 	inject(authorization.AuthorizationAttributes, docsAuthorization)
 	inject(authorization.PermissionAttributes, docsPermission)

--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -164,13 +164,30 @@ func TestAuthentication(t *testing.T) {
 			Config: p.Config(`
 				authentication = {
 					sso = {
-						sso_suite_style_id = "koko"
+						sso_suite_settings = {
+							hide_saml = true
+							hide_oidc = true
+						}
+					}
+				}
+			`),
+			ExpectError: regexp.MustCompile("The attributes hide_oidc and hide_saml cannot both be true"),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				authentication = {
+					sso = {
+						sso_suite_settings = {
+							style_id = "koko"
+							hide_saml = true
+						}
 					}
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"authentication.sso": map[string]any{
-					"sso_suite_style_id": "koko",
+				"authentication.sso.sso_suite_settings": map[string]any{
+					"style_id":  "koko",
+					"hide_saml": true,
 				},
 			}),
 		},

--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -160,5 +160,19 @@ func TestAuthentication(t *testing.T) {
 				},
 			}),
 		},
+		resource.TestStep{
+			Config: p.Config(`
+				authentication = {
+					sso = {
+						sso_suite_style_id = "koko"
+					}
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"authentication.sso": map[string]any{
+					"sso_suite_style_id": "koko",
+				},
+			}),
+		},
 	)
 }

--- a/internal/models/project/authentication/sso.go
+++ b/internal/models/project/authentication/sso.go
@@ -2,33 +2,24 @@ package authentication
 
 import (
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/boolattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/objattr"
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 var SSOAttributes = map[string]schema.Attribute{
-	"disabled":                      boolattr.Default(false),
-	"merge_users":                   boolattr.Default(false),
-	"redirect_url":                  stringattr.Default(""),
-	"sso_suite_style_id":            stringattr.Default(""),
-	"hide_sso_suite_scim":           boolattr.Default(false),
-	"hide_sso_suite_groups_mapping": boolattr.Default(false),
-	"hide_sso_suite_domains":        boolattr.Default(false),
-	"hide_sso_suite_saml":           boolattr.Default(false),
-	"hide_sso_suite_oidc":           boolattr.Default(false),
+	"disabled":           boolattr.Default(false),
+	"merge_users":        boolattr.Default(false),
+	"redirect_url":       stringattr.Default(""),
+	"sso_suite_settings": objattr.Default(SSOSuiteDefault, SSOSuiteAttributes, SSOSuiteValidator),
 }
 
 type SSOModel struct {
-	Disabled                  boolattr.Type   `tfsdk:"disabled"`
-	MergeUsers                boolattr.Type   `tfsdk:"merge_users"`
-	RedirectURL               stringattr.Type `tfsdk:"redirect_url"`
-	SsoSuiteStyleId           stringattr.Type `tfsdk:"sso_suite_style_id"`
-	HideSsoSuiteScim          boolattr.Type   `tfsdk:"hide_sso_suite_scim"`
-	HideSsoSuiteGroupsMapping boolattr.Type   `tfsdk:"hide_sso_suite_groups_mapping"`
-	HideSsoSuiteDomains       boolattr.Type   `tfsdk:"hide_sso_suite_domains"`
-	HideSsoSuiteSaml          boolattr.Type   `tfsdk:"hide_sso_suite_saml"`
-	HideSsoSuiteOidc          boolattr.Type   `tfsdk:"hide_sso_suite_oidc"`
+	Disabled         boolattr.Type               `tfsdk:"disabled"`
+	MergeUsers       boolattr.Type               `tfsdk:"merge_users"`
+	RedirectURL      stringattr.Type             `tfsdk:"redirect_url"`
+	SSOSuiteSettings objattr.Type[SSOSuiteModel] `tfsdk:"sso_suite_settings"`
 }
 
 func (m *SSOModel) Values(h *helpers.Handler) map[string]any {
@@ -36,12 +27,8 @@ func (m *SSOModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.GetNot(m.Disabled, data, "enabled")
 	boolattr.Get(m.MergeUsers, data, "mergeUsers")
 	stringattr.Get(m.RedirectURL, data, "redirectUrl")
-	stringattr.Get(m.SsoSuiteStyleId, data, "ssoSuiteStyleId")
-	boolattr.Get(m.HideSsoSuiteScim, data, "hideSsoSuiteScim")
-	boolattr.Get(m.HideSsoSuiteGroupsMapping, data, "hideSsoSuiteGroupsMapping")
-	boolattr.Get(m.HideSsoSuiteDomains, data, "hideSsoSuiteDomains")
-	boolattr.Get(m.HideSsoSuiteSaml, data, "hideSsoSuiteSaml")
-	boolattr.Get(m.HideSsoSuiteOidc, data, "hideSsoSuiteOidc")
+	objattr.Get(m.SSOSuiteSettings, data, helpers.RootKey, h)
+
 	return data
 }
 
@@ -49,10 +36,66 @@ func (m *SSOModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.SetNot(&m.Disabled, data, "enabled")
 	boolattr.Set(&m.MergeUsers, data, "mergeUsers")
 	stringattr.Set(&m.RedirectURL, data, "redirectUrl")
-	stringattr.Set(&m.SsoSuiteStyleId, data, "ssoSuiteStyleId")
-	boolattr.Set(&m.HideSsoSuiteScim, data, "hideSsoSuiteScim")
-	boolattr.Set(&m.HideSsoSuiteGroupsMapping, data, "hideSsoSuiteGroupsMapping")
-	boolattr.Set(&m.HideSsoSuiteDomains, data, "hideSsoSuiteDomains")
-	boolattr.Set(&m.HideSsoSuiteSaml, data, "hideSsoSuiteSaml")
-	boolattr.Set(&m.HideSsoSuiteOidc, data, "hideSsoSuiteOidc")
+	objattr.Set(&m.SSOSuiteSettings, data, helpers.RootKey, h)
+}
+
+// SSO Suite Settings
+
+var SSOSuiteValidator = objattr.NewValidator[SSOSuiteModel]("must have a valid configuration")
+
+var SSOSuiteAttributes = map[string]schema.Attribute{
+	"style_id":            stringattr.Default(""),
+	"hide_scim":           boolattr.Default(false),
+	"hide_groups_mapping": boolattr.Default(false),
+	"hide_domains":        boolattr.Default(false),
+	"hide_saml":           boolattr.Default(false),
+	"hide_oidc":           boolattr.Default(false),
+}
+
+type SSOSuiteModel struct {
+	StyleId           stringattr.Type `tfsdk:"style_id"`
+	HideScim          boolattr.Type   `tfsdk:"hide_scim"`
+	HideGroupsMapping boolattr.Type   `tfsdk:"hide_groups_mapping"`
+	HideDomains       boolattr.Type   `tfsdk:"hide_domains"`
+	HideSaml          boolattr.Type   `tfsdk:"hide_saml"`
+	HideOidc          boolattr.Type   `tfsdk:"hide_oidc"`
+}
+
+var SSOSuiteDefault = &SSOSuiteModel{
+	StyleId:           stringattr.Value(""),
+	HideScim:          boolattr.Value(false),
+	HideGroupsMapping: boolattr.Value(false),
+	HideDomains:       boolattr.Value(false),
+	HideSaml:          boolattr.Value(false),
+	HideOidc:          boolattr.Value(false),
+}
+
+func (m *SSOSuiteModel) Values(h *helpers.Handler) map[string]any {
+	data := map[string]any{}
+	stringattr.Get(m.StyleId, data, "ssoSuiteStyleId")
+	boolattr.Get(m.HideScim, data, "hideSsoSuiteScim")
+	boolattr.Get(m.HideGroupsMapping, data, "hideSsoSuiteGroupsMapping")
+	boolattr.Get(m.HideDomains, data, "hideSsoSuiteDomains")
+	boolattr.Get(m.HideSaml, data, "hideSsoSuiteSaml")
+	boolattr.Get(m.HideOidc, data, "hideSsoSuiteOidc")
+	return data
+}
+
+func (m *SSOSuiteModel) SetValues(h *helpers.Handler, data map[string]any) {
+	stringattr.Set(&m.StyleId, data, "ssoSuiteStyleId")
+	boolattr.Set(&m.HideScim, data, "hideSsoSuiteScim")
+	boolattr.Set(&m.HideGroupsMapping, data, "hideSsoSuiteGroupsMapping")
+	boolattr.Set(&m.HideDomains, data, "hideSsoSuiteDomains")
+	boolattr.Set(&m.HideSaml, data, "hideSsoSuiteSaml")
+	boolattr.Set(&m.HideOidc, data, "hideSsoSuiteOidc")
+}
+
+func (m *SSOSuiteModel) Validate(h *helpers.Handler) {
+	if helpers.HasUnknownValues(m.HideSaml, m.HideOidc) {
+		return
+	}
+
+	if m.HideSaml.ValueBool() && m.HideOidc.ValueBool() {
+		h.Invalid("The attributes hide_oidc and hide_saml cannot both be true")
+	}
 }

--- a/internal/models/project/authentication/sso.go
+++ b/internal/models/project/authentication/sso.go
@@ -28,7 +28,6 @@ func (m *SSOModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.Get(m.MergeUsers, data, "mergeUsers")
 	stringattr.Get(m.RedirectURL, data, "redirectUrl")
 	objattr.Get(m.SSOSuiteSettings, data, helpers.RootKey, h)
-
 	return data
 }
 

--- a/internal/models/project/authentication/sso.go
+++ b/internal/models/project/authentication/sso.go
@@ -8,15 +8,27 @@ import (
 )
 
 var SSOAttributes = map[string]schema.Attribute{
-	"disabled":     boolattr.Default(false),
-	"merge_users":  boolattr.Default(false),
-	"redirect_url": stringattr.Default(""),
+	"disabled":                      boolattr.Default(false),
+	"merge_users":                   boolattr.Default(false),
+	"redirect_url":                  stringattr.Default(""),
+	"sso_suite_style_id":            stringattr.Default(""),
+	"hide_sso_suite_scim":           boolattr.Default(false),
+	"hide_sso_suite_groups_mapping": boolattr.Default(false),
+	"hide_sso_suite_domains":        boolattr.Default(false),
+	"hide_sso_suite_saml":           boolattr.Default(false),
+	"hide_sso_suite_oidc":           boolattr.Default(false),
 }
 
 type SSOModel struct {
-	Disabled    boolattr.Type   `tfsdk:"disabled"`
-	MergeUsers  boolattr.Type   `tfsdk:"merge_users"`
-	RedirectURL stringattr.Type `tfsdk:"redirect_url"`
+	Disabled                  boolattr.Type   `tfsdk:"disabled"`
+	MergeUsers                boolattr.Type   `tfsdk:"merge_users"`
+	RedirectURL               stringattr.Type `tfsdk:"redirect_url"`
+	SsoSuiteStyleId           stringattr.Type `tfsdk:"sso_suite_style_id"`
+	HideSsoSuiteScim          boolattr.Type   `tfsdk:"hide_sso_suite_scim"`
+	HideSsoSuiteGroupsMapping boolattr.Type   `tfsdk:"hide_sso_suite_groups_mapping"`
+	HideSsoSuiteDomains       boolattr.Type   `tfsdk:"hide_sso_suite_domains"`
+	HideSsoSuiteSaml          boolattr.Type   `tfsdk:"hide_sso_suite_saml"`
+	HideSsoSuiteOidc          boolattr.Type   `tfsdk:"hide_sso_suite_oidc"`
 }
 
 func (m *SSOModel) Values(h *helpers.Handler) map[string]any {
@@ -24,6 +36,12 @@ func (m *SSOModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.GetNot(m.Disabled, data, "enabled")
 	boolattr.Get(m.MergeUsers, data, "mergeUsers")
 	stringattr.Get(m.RedirectURL, data, "redirectUrl")
+	stringattr.Get(m.SsoSuiteStyleId, data, "ssoSuiteStyleId")
+	boolattr.Get(m.HideSsoSuiteScim, data, "hideSsoSuiteScim")
+	boolattr.Get(m.HideSsoSuiteGroupsMapping, data, "hideSsoSuiteGroupsMapping")
+	boolattr.Get(m.HideSsoSuiteDomains, data, "hideSsoSuiteDomains")
+	boolattr.Get(m.HideSsoSuiteSaml, data, "hideSsoSuiteSaml")
+	boolattr.Get(m.HideSsoSuiteOidc, data, "hideSsoSuiteOidc")
 	return data
 }
 
@@ -31,4 +49,10 @@ func (m *SSOModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.SetNot(&m.Disabled, data, "enabled")
 	boolattr.Set(&m.MergeUsers, data, "mergeUsers")
 	stringattr.Set(&m.RedirectURL, data, "redirectUrl")
+	stringattr.Set(&m.SsoSuiteStyleId, data, "ssoSuiteStyleId")
+	boolattr.Set(&m.HideSsoSuiteScim, data, "hideSsoSuiteScim")
+	boolattr.Set(&m.HideSsoSuiteGroupsMapping, data, "hideSsoSuiteGroupsMapping")
+	boolattr.Set(&m.HideSsoSuiteDomains, data, "hideSsoSuiteDomains")
+	boolattr.Set(&m.HideSsoSuiteSaml, data, "hideSsoSuiteSaml")
+	boolattr.Set(&m.HideSsoSuiteOidc, data, "hideSsoSuiteOidc")
 }

--- a/internal/models/project/authentication/sso.go
+++ b/internal/models/project/authentication/sso.go
@@ -52,49 +52,49 @@ var SSOSuiteAttributes = map[string]schema.Attribute{
 }
 
 type SSOSuiteModel struct {
-	StyleId           stringattr.Type `tfsdk:"style_id"`
-	HideScim          boolattr.Type   `tfsdk:"hide_scim"`
+	StyleID           stringattr.Type `tfsdk:"style_id"`
+	HideSCIM          boolattr.Type   `tfsdk:"hide_scim"`
 	HideGroupsMapping boolattr.Type   `tfsdk:"hide_groups_mapping"`
 	HideDomains       boolattr.Type   `tfsdk:"hide_domains"`
-	HideSaml          boolattr.Type   `tfsdk:"hide_saml"`
-	HideOidc          boolattr.Type   `tfsdk:"hide_oidc"`
+	HideSAML          boolattr.Type   `tfsdk:"hide_saml"`
+	HideOIDC          boolattr.Type   `tfsdk:"hide_oidc"`
 }
 
 var SSOSuiteDefault = &SSOSuiteModel{
-	StyleId:           stringattr.Value(""),
-	HideScim:          boolattr.Value(false),
+	StyleID:           stringattr.Value(""),
+	HideSCIM:          boolattr.Value(false),
 	HideGroupsMapping: boolattr.Value(false),
 	HideDomains:       boolattr.Value(false),
-	HideSaml:          boolattr.Value(false),
-	HideOidc:          boolattr.Value(false),
+	HideSAML:          boolattr.Value(false),
+	HideOIDC:          boolattr.Value(false),
 }
 
 func (m *SSOSuiteModel) Values(h *helpers.Handler) map[string]any {
 	data := map[string]any{}
-	stringattr.Get(m.StyleId, data, "ssoSuiteStyleId")
-	boolattr.Get(m.HideScim, data, "hideSsoSuiteScim")
+	stringattr.Get(m.StyleID, data, "ssoSuiteStyleId")
+	boolattr.Get(m.HideSCIM, data, "hideSsoSuiteScim")
 	boolattr.Get(m.HideGroupsMapping, data, "hideSsoSuiteGroupsMapping")
 	boolattr.Get(m.HideDomains, data, "hideSsoSuiteDomains")
-	boolattr.Get(m.HideSaml, data, "hideSsoSuiteSaml")
-	boolattr.Get(m.HideOidc, data, "hideSsoSuiteOidc")
+	boolattr.Get(m.HideSAML, data, "hideSsoSuiteSaml")
+	boolattr.Get(m.HideOIDC, data, "hideSsoSuiteOidc")
 	return data
 }
 
 func (m *SSOSuiteModel) SetValues(h *helpers.Handler, data map[string]any) {
-	stringattr.Set(&m.StyleId, data, "ssoSuiteStyleId")
-	boolattr.Set(&m.HideScim, data, "hideSsoSuiteScim")
+	stringattr.Set(&m.StyleID, data, "ssoSuiteStyleId")
+	boolattr.Set(&m.HideSCIM, data, "hideSsoSuiteScim")
 	boolattr.Set(&m.HideGroupsMapping, data, "hideSsoSuiteGroupsMapping")
 	boolattr.Set(&m.HideDomains, data, "hideSsoSuiteDomains")
-	boolattr.Set(&m.HideSaml, data, "hideSsoSuiteSaml")
-	boolattr.Set(&m.HideOidc, data, "hideSsoSuiteOidc")
+	boolattr.Set(&m.HideSAML, data, "hideSsoSuiteSaml")
+	boolattr.Set(&m.HideOIDC, data, "hideSsoSuiteOidc")
 }
 
 func (m *SSOSuiteModel) Validate(h *helpers.Handler) {
-	if helpers.HasUnknownValues(m.HideSaml, m.HideOidc) {
+	if helpers.HasUnknownValues(m.HideSAML, m.HideOIDC) {
 		return
 	}
 
-	if m.HideSaml.ValueBool() && m.HideOidc.ValueBool() {
+	if m.HideSAML.ValueBool() && m.HideOIDC.ValueBool() {
 		h.Invalid("The attributes hide_oidc and hide_saml cannot both be true")
 	}
 }


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/11434

## Description
Introduces new SSO Suite attributes for style customization (sso_suite_style_id) and options to hide SCIM, groups mapping, domains, SAML, and OIDC configuration sections. Updates documentation and SSOModel to support these new fields, allowing more granular control over the SSO Suite interface.

## Must
- [x] Acceptance Tests
- [x] Schema Compatibility
- [ ] Documentation Updates
