### PR TITLE
Add mask_errors attribute to password settings

### DIFF
--- a/docs/raw/project/authentication/password.md
+++ b/docs/raw/project/authentication/password.md
@@ -115,6 +115,16 @@ Whether passwords must contain at least one uppercase letter.
 
 
 
+mask_errors
+-----------
+
+- Type: `bool` 
+
+Prevents information about user accounts from being revealed in error messages, e.g.,
+whether a user already exists.
+
+
+
 email_service
 -------------
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -762,6 +762,7 @@ Optional:
 - `lock` (Boolean) Whether the user account should be locked after a specified number of failed login attempts.
 - `lock_attempts` (Number) The number of failed login attempts allowed before an account is locked.
 - `lowercase` (Boolean) Whether passwords must contain at least one lowercase letter.
+- `mask_errors` (Boolean) Prevents information about user accounts from being revealed in error messages, e.g., whether a user already exists.
 - `min_length` (Number) The minimum length of the password that users are required to use. The maximum length is always `64`.
 - `non_alphanumeric` (Boolean) Whether passwords must contain at least one non-alphanumeric character (e.g. `!`, `@`, `#`).
 - `number` (Boolean) Whether passwords must contain at least one number.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -225,6 +225,8 @@ var docsPassword = map[string]string{
 	"reuse_amount": "The number of previous passwords whose hashes are kept to prevent users from " +
 	                "reusing old passwords.",
 	"uppercase": "Whether passwords must contain at least one uppercase letter.",
+	"mask_errors": "Prevents information about user accounts from being revealed in error messages, e.g., " +
+	               "whether a user already exists.",
 	"email_service": "Settings related to sending password reset emails as part of the password feature.",
 }
 

--- a/internal/models/project/authentication/password.go
+++ b/internal/models/project/authentication/password.go
@@ -23,6 +23,7 @@ var PasswordAttributes = map[string]schema.Attribute{
 	"reuse":            boolattr.Optional(),
 	"reuse_amount":     intattr.Optional(int64validator.Between(1, 50)),
 	"uppercase":        boolattr.Optional(),
+	"mask_errors":      boolattr.Default(false),
 	"email_service":    objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
 }
 
@@ -39,6 +40,7 @@ type PasswordModel struct {
 	Reuse           boolattr.Type                             `tfsdk:"reuse"`
 	ReuseAmount     intattr.Type                              `tfsdk:"reuse_amount"`
 	Uppercase       boolattr.Type                             `tfsdk:"uppercase"`
+	MaskErrors      boolattr.Type                             `tfsdk:"mask_errors"`
 	EmailService    objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
 }
 
@@ -56,6 +58,7 @@ func (m *PasswordModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.Get(m.Reuse, data, "reuse")
 	intattr.Get(m.ReuseAmount, data, "reuseAmount")
 	boolattr.Get(m.Uppercase, data, "uppercase")
+	boolattr.Get(m.MaskErrors, data, "maskError")
 	objattr.Get(m.EmailService, data, helpers.RootKey, h)
 	return data
 }
@@ -73,6 +76,7 @@ func (m *PasswordModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.Set(&m.Reuse, data, "reuse")
 	intattr.Set(&m.ReuseAmount, data, "reuseAmount")
 	boolattr.Set(&m.Uppercase, data, "uppercase")
+	boolattr.Set(&m.MaskErrors, data, "maskError")
 	objattr.Set(&m.EmailService, data, helpers.RootKey, h)
 }
 


### PR DESCRIPTION
## Related Issues
Resolves 

## Description
- Add `mask_errors` attribute to password settings

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
