### PR TITLE
[feature] Add force_domain_verification to SSO suite settings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Preserve authored Markdown formatting in docs
+docs/**/*.md

--- a/docs/raw/project/authentication/sso.md
+++ b/docs/raw/project/authentication/sso.md
@@ -102,3 +102,12 @@ hide_oidc
 - Type: `bool` 
 
 Setting this to `true` will hide the OIDC configuration option.
+
+
+
+force_domain_verification
+-------------------------
+
+- Type: `bool` 
+
+Setting this to `true` will allow only verified domains to be used.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -819,6 +819,7 @@ Optional:
 
 Optional:
 
+- `force_domain_verification` (Boolean) Setting this to `true` will allow only verified domains to be used.
 - `hide_domains` (Boolean) Setting this to `true` will hide the domains configuration section in the SSO Suite interface.
 - `hide_groups_mapping` (Boolean) Setting this to `true` will hide the groups mapping configuration section in the SSO Suite interface.
 - `hide_oidc` (Boolean) Setting this to `true` will hide the OIDC configuration option.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -250,6 +250,7 @@ var docsSSOSuite = map[string]string{
 	"hide_domains": "Setting this to `true` will hide the domains configuration section in the SSO Suite interface.",
 	"hide_saml": "Setting this to `true` will hide the SAML configuration option.",
 	"hide_oidc": "Setting this to `true` will hide the OIDC configuration option.",
+	"force_domain_verification": "Setting this to `true` will allow only verified domains to be used.",
 }
 
 var docsTOTP = map[string]string{

--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -191,5 +191,50 @@ func TestAuthentication(t *testing.T) {
 				},
 			}),
 		},
+		resource.TestStep{
+			Config: p.Config(`
+				authentication = {
+					sso = {
+						sso_suite_settings = {
+							hide_domains = true
+							force_domain_verification = true
+						}
+					}
+				}
+			`),
+			ExpectError: regexp.MustCompile("The attributes force_domain_verification and hide_domains cannot both be true"),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				authentication = {
+					sso = {
+						sso_suite_settings = {
+							force_domain_verification = true
+						}
+					}
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"authentication.sso.sso_suite_settings": map[string]any{
+					"force_domain_verification": true,
+				},
+			}),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				authentication = {
+					sso = {
+						sso_suite_settings = {
+							force_domain_verification = false
+						}
+					}
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"authentication.sso.sso_suite_settings": map[string]any{
+					"force_domain_verification": false,
+				},
+			}),
+		},
 	)
 }

--- a/internal/models/project/authentication/sso.go
+++ b/internal/models/project/authentication/sso.go
@@ -90,6 +90,7 @@ func (m *SSOSuiteModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.Set(&m.HideGroupsMapping, data, "hideSsoSuiteGroupsMapping")
 	boolattr.Set(&m.HideDomains, data, "hideSsoSuiteDomains")
 	boolattr.Set(&m.HideSAML, data, "hideSsoSuiteSaml")
+	boolattr.Set(&m.HideOIDC, data, "hideSsoSuiteOidc")
 	boolattr.Set(&m.ForceDomainVerification, data, "ssoSuiteForceDomainVerification")
 }
 

--- a/internal/models/project/authentication/sso.go
+++ b/internal/models/project/authentication/sso.go
@@ -43,30 +43,33 @@ func (m *SSOModel) SetValues(h *helpers.Handler, data map[string]any) {
 var SSOSuiteValidator = objattr.NewValidator[SSOSuiteModel]("must have a valid configuration")
 
 var SSOSuiteAttributes = map[string]schema.Attribute{
-	"style_id":            stringattr.Default(""),
-	"hide_scim":           boolattr.Default(false),
-	"hide_groups_mapping": boolattr.Default(false),
-	"hide_domains":        boolattr.Default(false),
-	"hide_saml":           boolattr.Default(false),
-	"hide_oidc":           boolattr.Default(false),
+	"style_id":                  stringattr.Default(""),
+	"hide_scim":                 boolattr.Default(false),
+	"hide_groups_mapping":       boolattr.Default(false),
+	"hide_domains":              boolattr.Default(false),
+	"hide_saml":                 boolattr.Default(false),
+	"hide_oidc":                 boolattr.Default(false),
+	"force_domain_verification": boolattr.Default(false),
 }
 
 type SSOSuiteModel struct {
-	StyleID           stringattr.Type `tfsdk:"style_id"`
-	HideSCIM          boolattr.Type   `tfsdk:"hide_scim"`
-	HideGroupsMapping boolattr.Type   `tfsdk:"hide_groups_mapping"`
-	HideDomains       boolattr.Type   `tfsdk:"hide_domains"`
-	HideSAML          boolattr.Type   `tfsdk:"hide_saml"`
-	HideOIDC          boolattr.Type   `tfsdk:"hide_oidc"`
+	StyleID                 stringattr.Type `tfsdk:"style_id"`
+	HideSCIM                boolattr.Type   `tfsdk:"hide_scim"`
+	HideGroupsMapping       boolattr.Type   `tfsdk:"hide_groups_mapping"`
+	HideDomains             boolattr.Type   `tfsdk:"hide_domains"`
+	HideSAML                boolattr.Type   `tfsdk:"hide_saml"`
+	HideOIDC                boolattr.Type   `tfsdk:"hide_oidc"`
+	ForceDomainVerification boolattr.Type   `tfsdk:"force_domain_verification"`
 }
 
 var SSOSuiteDefault = &SSOSuiteModel{
-	StyleID:           stringattr.Value(""),
-	HideSCIM:          boolattr.Value(false),
-	HideGroupsMapping: boolattr.Value(false),
-	HideDomains:       boolattr.Value(false),
-	HideSAML:          boolattr.Value(false),
-	HideOIDC:          boolattr.Value(false),
+	StyleID:                 stringattr.Value(""),
+	HideSCIM:                boolattr.Value(false),
+	HideGroupsMapping:       boolattr.Value(false),
+	HideDomains:             boolattr.Value(false),
+	HideSAML:                boolattr.Value(false),
+	HideOIDC:                boolattr.Value(false),
+	ForceDomainVerification: boolattr.Value(false),
 }
 
 func (m *SSOSuiteModel) Values(h *helpers.Handler) map[string]any {
@@ -77,6 +80,7 @@ func (m *SSOSuiteModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.Get(m.HideDomains, data, "hideSsoSuiteDomains")
 	boolattr.Get(m.HideSAML, data, "hideSsoSuiteSaml")
 	boolattr.Get(m.HideOIDC, data, "hideSsoSuiteOidc")
+	boolattr.Get(m.ForceDomainVerification, data, "ssoSuiteForceDomainVerification")
 	return data
 }
 
@@ -86,15 +90,19 @@ func (m *SSOSuiteModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.Set(&m.HideGroupsMapping, data, "hideSsoSuiteGroupsMapping")
 	boolattr.Set(&m.HideDomains, data, "hideSsoSuiteDomains")
 	boolattr.Set(&m.HideSAML, data, "hideSsoSuiteSaml")
-	boolattr.Set(&m.HideOIDC, data, "hideSsoSuiteOidc")
+	boolattr.Set(&m.ForceDomainVerification, data, "ssoSuiteForceDomainVerification")
 }
 
 func (m *SSOSuiteModel) Validate(h *helpers.Handler) {
 	if helpers.HasUnknownValues(m.HideSAML, m.HideOIDC) {
 		return
+	} else if m.HideSAML.ValueBool() && m.HideOIDC.ValueBool() {
+		h.Invalid("The attributes hide_oidc and hide_saml cannot both be true")
 	}
 
-	if m.HideSAML.ValueBool() && m.HideOIDC.ValueBool() {
-		h.Invalid("The attributes hide_oidc and hide_saml cannot both be true")
+	if helpers.HasUnknownValues(m.HideDomains, m.ForceDomainVerification) {
+		return
+	} else if m.HideDomains.ValueBool() && m.ForceDomainVerification.ValueBool() {
+		h.Invalid("The attributes force_domain_verification and hide_domains cannot both be true")
 	}
 }


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/12213

## Description
Introduces the force_domain_verification boolean attribute to SSO suite settings. ensures it cannot be enabled simultaneously with hide_domains.

## Must
- [x] Acceptance Tests
- [x] Schema Compatibility
- [ ] Documentation Updates
