### PR TITLE
Add support for FGA schema in authorization settings

### DIFF
--- a/docs/raw/project/authorization/authorization.md
+++ b/docs/raw/project/authorization/authorization.md
@@ -19,3 +19,13 @@ permissions
 - Type: `list` of `authorization.Permission`
 
 A list of `Permission` objects.
+
+
+
+fga
+----
+
+- Type: `string`
+
+The project's FGA schema, configured in the [Descope console](https://app.descope.com/authorization/fga)
+under the FGA tab. Use the code view to get the schema text and paste it as the value for this attribute.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1486,6 +1486,7 @@ Optional:
 
 Optional:
 
+- `fga` (String) The project's FGA schema, configured in the [Descope console](https://app.descope.com/authorization/fga) under the FGA tab. Use the code view to get the schema text and paste it as the value for this attribute.
 - `permissions` (Attributes List) A list of `Permission` objects. (see [below for nested schema](#nestedatt--authorization--permissions))
 - `roles` (Attributes List) A list of `Role` objects. (see [below for nested schema](#nestedatt--authorization--roles))
 
@@ -2700,6 +2701,7 @@ Required:
 
 Optional:
 
+- `action` (String) The user-initiated action for this assessment.
 - `assessment_score` (Number) When configured, the Recaptcha action will return the score without assessing the request. The score ranges between 0 and 1, where 1 is a human interaction and 0 is a bot.
 - `base_url` (String) Apply a custom url to the reCAPTCHA Enterprise scripts. This is useful when attempting to use reCAPTCHA globally. Defaults to https://www.google.com
 - `bot_threshold` (Number) The bot threshold is used to determine whether the request is a bot or a human. The score ranges between 0 and 1, where 1 is a human interaction and 0 is a bot. If the score is below this threshold, the request is considered a bot.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -441,6 +441,8 @@ var docsTOTP = map[string]string{
 var docsAuthorization = map[string]string{
 	"roles":       "A list of `Role` objects.",
 	"permissions": "A list of `Permission` objects.",
+	"fga": "The project's FGA schema, configured in the [Descope console](https://app.descope.com/authorization/fga) " +
+		"under the FGA tab. Use the code view to get the schema text and paste it as the value for this attribute.",
 }
 
 var docsPermission = map[string]string{
@@ -1031,6 +1033,7 @@ var docsRecaptchaEnterprise = map[string]string{
 	"api_key": "API key associated with the current project.",
 	"base_url": "Apply a custom url to the reCAPTCHA Enterprise scripts. This is useful when " +
 		"attempting to use reCAPTCHA globally. Defaults to https://www.google.com",
+	"action": "The user-initiated action for this assessment.",
 	"override_assessment": "Override the default assessment model. Note: Overriding assessment is intended " +
 		"for automated testing and should not be utilized in production environments.",
 	"bot_threshold": "The bot threshold is used to determine whether the request is a bot or a human. " +

--- a/internal/models/project/authorization/authorization.go
+++ b/internal/models/project/authorization/authorization.go
@@ -60,7 +60,7 @@ func (m *AuthorizationModel) Validate(h *helpers.Handler) {
 		return // skip validation if there are unknown values
 	}
 
-	if fga := m.FGA.ValueString(); fga != "" && !strings.HasPrefix(fga, "model AuthZ") {
+	if fga := strings.TrimSpace(m.FGA.ValueString()); fga != "" && !strings.HasPrefix(fga, "model AuthZ") {
 		h.Invalid("The 'fga' attribute must start with 'model AuthZ', make sure you're using the schema from the code view in the FGA tab in the Descope console")
 	}
 

--- a/internal/models/project/authorization/authorization.go
+++ b/internal/models/project/authorization/authorization.go
@@ -2,9 +2,11 @@ package authorization
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/listattr"
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/objattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/strsetattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -24,23 +26,27 @@ var AuthorizationModifier = objattr.NewModifier[AuthorizationModel]("maintains p
 var AuthorizationAttributes = map[string]schema.Attribute{
 	"roles":       listattr.Default[RoleModel](RoleAttributes),
 	"permissions": listattr.Default[PermissionModel](PermissionAttributes),
+	"fga":         stringattr.Default(""),
 }
 
 type AuthorizationModel struct {
 	Roles       listattr.Type[RoleModel]       `tfsdk:"roles"`
 	Permissions listattr.Type[PermissionModel] `tfsdk:"permissions"`
+	FGA         stringattr.Type                `tfsdk:"fga"`
 }
 
 func (m *AuthorizationModel) Values(h *helpers.Handler) map[string]any {
 	data := map[string]any{}
 	listattr.Get(m.Roles, data, "roles", h)
 	listattr.Get(m.Permissions, data, "permissions", h)
+	stringattr.Get(m.FGA, data, "fga")
 	return data
 }
 
 func (m *AuthorizationModel) SetValues(h *helpers.Handler, data map[string]any) {
 	listattr.SetMatchingNames(&m.Roles, data, "roles", "name", h)
 	listattr.SetMatchingNames(&m.Permissions, data, "permissions", "name", h)
+	stringattr.Set(&m.FGA, data, "fga", stringattr.SkipIfAlreadySet) // there might be formatting differences and we don't want to trigger inconsistency errors
 }
 
 func (m *AuthorizationModel) CollectReferences(h *helpers.Handler) {
@@ -50,8 +56,12 @@ func (m *AuthorizationModel) CollectReferences(h *helpers.Handler) {
 }
 
 func (m *AuthorizationModel) Validate(h *helpers.Handler) {
-	if helpers.HasUnknownValues(m.Permissions, m.Roles) {
+	if helpers.HasUnknownValues(m.Permissions, m.Roles, m.FGA) {
 		return // skip validation if there are unknown values
+	}
+
+	if fga := m.FGA.ValueString(); fga != "" && !strings.HasPrefix(fga, "model AuthZ") {
+		h.Invalid("The 'fga' attribute must start with 'model AuthZ', make sure you're using the schema from the code view in the FGA tab in the Descope console")
 	}
 
 	permissions := map[string]int{}

--- a/internal/models/project/authorization/authorization_test.go
+++ b/internal/models/project/authorization/authorization_test.go
@@ -138,5 +138,27 @@ func TestAuthorization(t *testing.T) {
 				"authorization.permissions.0.description": "Allowed to build and sign applications",
 			}),
 		},
+		resource.TestStep{
+			Config: p.Config(`
+				authorization = {
+					fga = "model AuthZ 1.0\n\ntype user\n\n"
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"authorization.roles.#":       0,
+				"authorization.permissions.#": 0,
+				"authorization.fga":           "model AuthZ 1.0\n\ntype user\n\n",
+			}),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				authorization = {}
+			`),
+			Check: p.Check(map[string]any{
+				"authorization.fga":           "",
+				"authorization.roles.#":       0,
+				"authorization.permissions.#": 0,
+			}),
+		},
 	)
 }

--- a/internal/models/project/connectors/connectors_test.go
+++ b/internal/models/project/connectors/connectors_test.go
@@ -1258,6 +1258,7 @@ func TestConnectors(t *testing.T) {
     						site_key = "ikzbbly"
     						api_key = "mhvece"
     						base_url = ""
+    						action = "xwjyy2"
     						override_assessment = true
     						bot_threshold = 12
     						assessment_score = 15
@@ -1275,6 +1276,7 @@ func TestConnectors(t *testing.T) {
 					"site_key":            "ikzbbly",
 					"api_key":             "mhvece",
 					"base_url":            "",
+					"action":              "xwjyy2",
 					"override_assessment": true,
 					"bot_threshold":       12,
 					"assessment_score":    15,

--- a/internal/models/project/connectors/recaptchaenterprise.go
+++ b/internal/models/project/connectors/recaptchaenterprise.go
@@ -22,6 +22,7 @@ var RecaptchaEnterpriseAttributes = map[string]schema.Attribute{
 	"site_key":            stringattr.Required(),
 	"api_key":             stringattr.SecretRequired(),
 	"base_url":            stringattr.Default(""),
+	"action":              stringattr.Default(""),
 	"override_assessment": boolattr.Default(false),
 	"bot_threshold":       floatattr.Default(0.5),
 	"assessment_score":    floatattr.Default(0.5),
@@ -38,6 +39,7 @@ type RecaptchaEnterpriseModel struct {
 	SiteKey            stringattr.Type `tfsdk:"site_key"`
 	APIKey             stringattr.Type `tfsdk:"api_key"`
 	BaseURL            stringattr.Type `tfsdk:"base_url"`
+	Action             stringattr.Type `tfsdk:"action"`
 	OverrideAssessment boolattr.Type   `tfsdk:"override_assessment"`
 	BotThreshold       floatattr.Type  `tfsdk:"bot_threshold"`
 	AssessmentScore    floatattr.Type  `tfsdk:"assessment_score"`
@@ -71,6 +73,7 @@ func (m *RecaptchaEnterpriseModel) ConfigurationValues(h *helpers.Handler) map[s
 	stringattr.Get(m.SiteKey, c, "siteKey")
 	stringattr.Get(m.APIKey, c, "apiKey")
 	stringattr.Get(m.BaseURL, c, "baseUrl")
+	stringattr.Get(m.Action, c, "action")
 	boolattr.Get(m.OverrideAssessment, c, "overrideAssessment")
 	floatattr.Get(m.BotThreshold, c, "botThreshold")
 	floatattr.Get(m.AssessmentScore, c, "assessmentScore")
@@ -83,6 +86,7 @@ func (m *RecaptchaEnterpriseModel) SetConfigurationValues(c map[string]any, h *h
 	stringattr.Set(&m.SiteKey, c, "siteKey")
 	stringattr.Nil(&m.APIKey)
 	stringattr.Set(&m.BaseURL, c, "baseUrl")
+	stringattr.Set(&m.Action, c, "action")
 	boolattr.Set(&m.OverrideAssessment, c, "overrideAssessment")
 	floatattr.Set(&m.BotThreshold, c, "botThreshold")
 	floatattr.Set(&m.AssessmentScore, c, "assessmentScore")

--- a/tools/terragen/conngen/naming.json
+++ b/tools/terragen/conngen/naming.json
@@ -336,6 +336,10 @@
       "attribute": "account_uid",
       "struct": "AccountUID"
     },
+    "action": {
+      "attribute": "action",
+      "struct": "Action"
+    },
     "addressTypes": {
       "attribute": "address_types",
       "struct": "AddressTypes"


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/15046
Resolves https://github.com/descope/etc/issues/15043

## Description
- Add support for FGA schema in authorization settings

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
