### PR TITLE
feat(password): add setting for any case letter requirement

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -416,6 +416,7 @@ var docsPassword = map[string]string{
 	"temporary_lock":          "Whether the user account should be temporarily locked after a specified number of failed login attempts.",
 	"temporary_lock_attempts": "The number of failed login attempts allowed before an account is temporarily locked.",
 	"temporary_lock_duration": "The amount of time before the user can sign in again after the account is temporarily locked.",
+	"any_letter":              "Whether passwords must contain at least one letter (uppercase or lowercase).",
 	"lowercase":               "Whether passwords must contain at least one lowercase letter.",
 	"min_length":              "The minimum length of the password that users are required to use. The maximum length is always `64`.",
 	"non_alphanumeric":        "Whether passwords must contain at least one non-alphanumeric character (e.g. `!`, `@`, `#`).",

--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -448,5 +448,21 @@ func TestAuthentication(t *testing.T) {
 				},
 			}),
 		},
+		resource.TestStep{
+			Config: p.Config(`
+				authentication = {
+					password = {
+						any_letter = true
+						lowercase = false
+						uppercase = false
+					}
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"authentication.password.any_letter": true,
+				"authentication.password.lowercase":  false,
+				"authentication.password.uppercase":  false,
+			}),
+		},
 	)
 }

--- a/internal/models/project/authentication/password.go
+++ b/internal/models/project/authentication/password.go
@@ -27,6 +27,7 @@ var PasswordAttributes = map[string]schema.Attribute{
 	"reuse":                   boolattr.Optional(),
 	"reuse_amount":            intattr.Optional(int64validator.Between(1, 50)),
 	"uppercase":               boolattr.Optional(),
+	"any_letter":              boolattr.Optional(),
 	"mask_errors":             boolattr.Default(false),
 	"email_service":           objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
 }
@@ -47,6 +48,7 @@ type PasswordModel struct {
 	Reuse                 boolattr.Type                             `tfsdk:"reuse"`
 	ReuseAmount           intattr.Type                              `tfsdk:"reuse_amount"`
 	Uppercase             boolattr.Type                             `tfsdk:"uppercase"`
+	AnyLetter             boolattr.Type                             `tfsdk:"any_letter"`
 	MaskErrors            boolattr.Type                             `tfsdk:"mask_errors"`
 	EmailService          objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
 }
@@ -68,6 +70,7 @@ func (m *PasswordModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.Get(m.Reuse, data, "reuse")
 	intattr.Get(m.ReuseAmount, data, "reuseAmount")
 	boolattr.Get(m.Uppercase, data, "uppercase")
+	boolattr.Get(m.AnyLetter, data, "anyLetter")
 	boolattr.Get(m.MaskErrors, data, "maskError")
 	objattr.Get(m.EmailService, data, helpers.RootKey, h)
 	return data
@@ -89,6 +92,7 @@ func (m *PasswordModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.Set(&m.Reuse, data, "reuse")
 	intattr.Set(&m.ReuseAmount, data, "reuseAmount")
 	boolattr.Set(&m.Uppercase, data, "uppercase")
+	boolattr.Set(&m.AnyLetter, data, "anyLetter")
 	boolattr.Set(&m.MaskErrors, data, "maskError")
 	objattr.Set(&m.EmailService, data, helpers.RootKey, h)
 }


### PR DESCRIPTION
Fixes descope/descope#761

[View workflow run](https://github.com/descope/shuni/actions/runs/25490021434)

## ✅ Terraform Provider Changes Complete

I've successfully added support for the `any_letter` password policy field to the Terraform provider.

### Changes Made

**File Modified**: `internal/models/project/authentication/password.go`

Added the `any_letter` field in 4 locations:

1. **Schema Attributes** (line 30) - Added `"any_letter": boolattr.Optional()`
   - Makes the field available in Terraform configurations
   - Optional boolean attribute (consistent with `lowercase` and `uppercase`)

2. **Model Struct** (line 51) - Added `AnyLetter boolattr.Type`
   - Internal Go struct field with proper tfsdk tag

3. **Values() Method** (line 73) - Added `boolattr.Get(m.AnyLetter, data, "anyLetter")`
   - Maps Terraform's `any_letter` to API's `anyLetter` field when creating/updating

4. **SetValues() Method** (line 95) - Added `boolattr.Set(&m.AnyLetter, data, "anyLetter")`
   - Maps API's `anyLetter` back to Terraform's `any_letter` when reading

### How It Works

Users can now configure password policies in Terraform like this:

```hcl
resource "descope_project" "example" {
  name = "My Project"
  
  authentication {
    password {
      any_letter = true  # Require at least one letter (any case)
      # OR use separate requirements:
      # lowercase = true
      # uppercase = true
    }
  }
}
```

When `any_letter = true`:
- Password must contain at least one Unicode letter (`\p{L}`)
- Can be uppercase OR lowercase (not both required)
- Aligns with backend validation logic

### Quality Checks

✅ **Format**: go fmt - passed  
✅ **Build**: go build - passed  
✅ **Vet**: go vet - passed  

### Commit

Created atomic commit following conventional commits:
- `feat(password): add any_letter field to password policy settings`
- Descriptive body explaining the change and backend mapping
- References related backend PR (descope/descope#761)

The Terraform provider is now ready to support the new password policy feature! 🐕

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*