### PR TITLE
test(widgets): add anyLetter to password policy preview fixture

### DIFF
--- a/internal/models/project/widgets/tests/testwidget.json
+++ b/internal/models/project/widgets/tests/testwidget.json
@@ -1883,6 +1883,7 @@
                 "data-errormessage-pattern-mismatch": "Passwords do not match",
                 "data-errormessage-type-mismatch": "Value does not comply with requirements",
                 "data-errormessage-value-missing": "Please fill out this field.",
+                "data-password-policy-message-anyletter": "1 letter (any case)",
                 "data-password-policy-message-lowercase": "1 lowercase letter",
                 "data-password-policy-message-minlength": "Minimum {{value}} characters",
                 "data-password-policy-message-nonalphanumeric": "1 symbol",


### PR DESCRIPTION
## Summary
- Adds \`'data-password-policy-message-anyletter': '1 letter (any case)'\` to the test widget fixture so it matches the templates updated in descope/content#1838
- No provider behavior change; this is a test asset only

Related issue: descope/etc#15616. Companion to descope/backend#868, descope/web-components-ui#1026, descope/console-app#5229, descope/content#1838.

## Test plan
- [x] Widget snapshot test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)