### PR TITLE
feat(applications): add mtls_client_auth_methods to OIDC applications (RFC 8705)

### DIFF
--- a/internal/models/project/applications/mtls.go
+++ b/internal/models/project/applications/mtls.go
@@ -1,0 +1,112 @@
+package applications
+
+import (
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/listattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/objattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
+	"github.com/descope/terraform-provider-descope/internal/models/helpers"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// MTLSCredential
+
+var MTLSCredentialAttributes = map[string]schema.Attribute{
+	"id":         stringattr.Optional(),
+	"name":       stringattr.Required(stringattr.StandardLenValidator),
+	"subject_dn": stringattr.Default(""),
+	"pem":        stringattr.Default(""),
+	"thumbprint": stringattr.Optional(),
+}
+
+type MTLSCredentialModel struct {
+	ID         stringattr.Type `tfsdk:"id"`
+	Name       stringattr.Type `tfsdk:"name"`
+	SubjectDN  stringattr.Type `tfsdk:"subject_dn"`
+	PEM        stringattr.Type `tfsdk:"pem"`
+	Thumbprint stringattr.Type `tfsdk:"thumbprint"`
+}
+
+func (m *MTLSCredentialModel) Values(h *helpers.Handler) map[string]any {
+	data := map[string]any{}
+	stringattr.Get(m.ID, data, "id")
+	stringattr.Get(m.Name, data, "name")
+	stringattr.Get(m.SubjectDN, data, "subjectDn")
+	stringattr.Get(m.PEM, data, "pem")
+	return data
+}
+
+func (m *MTLSCredentialModel) SetValues(h *helpers.Handler, data map[string]any) {
+	stringattr.Set(&m.ID, data, "id")
+	stringattr.Set(&m.Name, data, "name")
+	stringattr.Set(&m.SubjectDN, data, "subjectDn")
+	stringattr.Set(&m.PEM, data, "pem")
+	stringattr.Set(&m.Thumbprint, data, "thumbprint")
+}
+
+func (m *MTLSCredentialModel) GetName() stringattr.Type { return m.Name }
+func (m *MTLSCredentialModel) GetID() stringattr.Type   { return m.ID }
+func (m *MTLSCredentialModel) SetID(id stringattr.Type) { m.ID = id }
+
+// MTLSTLSClientAuth
+
+var MTLSTLSClientAuthAttributes = map[string]schema.Attribute{
+	"credentials": listattr.Default[MTLSCredentialModel](MTLSCredentialAttributes),
+}
+
+type MTLSTLSClientAuthModel struct {
+	Credentials listattr.Type[MTLSCredentialModel] `tfsdk:"credentials"`
+}
+
+func (m *MTLSTLSClientAuthModel) Values(h *helpers.Handler) map[string]any {
+	data := map[string]any{}
+	listattr.Get(m.Credentials, data, "credentials", h)
+	return data
+}
+
+func (m *MTLSTLSClientAuthModel) SetValues(h *helpers.Handler, data map[string]any) {
+	listattr.SetMatchingNames(&m.Credentials, data, "credentials", "name", h)
+}
+
+// MTLSSelfSignedTLSClientAuth
+
+var MTLSSelfSignedTLSClientAuthAttributes = map[string]schema.Attribute{
+	"credentials": listattr.Default[MTLSCredentialModel](MTLSCredentialAttributes),
+}
+
+type MTLSSelfSignedTLSClientAuthModel struct {
+	Credentials listattr.Type[MTLSCredentialModel] `tfsdk:"credentials"`
+}
+
+func (m *MTLSSelfSignedTLSClientAuthModel) Values(h *helpers.Handler) map[string]any {
+	data := map[string]any{}
+	listattr.Get(m.Credentials, data, "credentials", h)
+	return data
+}
+
+func (m *MTLSSelfSignedTLSClientAuthModel) SetValues(h *helpers.Handler, data map[string]any) {
+	listattr.SetMatchingNames(&m.Credentials, data, "credentials", "name", h)
+}
+
+// MTLSClientAuthMethods
+
+var MTLSClientAuthMethodsAttributes = map[string]schema.Attribute{
+	"tls_client_auth":             objattr.Default[MTLSTLSClientAuthModel](nil, MTLSTLSClientAuthAttributes),
+	"self_signed_tls_client_auth": objattr.Default[MTLSSelfSignedTLSClientAuthModel](nil, MTLSSelfSignedTLSClientAuthAttributes),
+}
+
+type MTLSClientAuthMethodsModel struct {
+	TLSClientAuth           objattr.Type[MTLSTLSClientAuthModel]           `tfsdk:"tls_client_auth"`
+	SelfSignedTLSClientAuth objattr.Type[MTLSSelfSignedTLSClientAuthModel] `tfsdk:"self_signed_tls_client_auth"`
+}
+
+func (m *MTLSClientAuthMethodsModel) Values(h *helpers.Handler) map[string]any {
+	data := map[string]any{}
+	objattr.Get(m.TLSClientAuth, data, "tlsClientAuth", h)
+	objattr.Get(m.SelfSignedTLSClientAuth, data, "selfSignedTlsClientAuth", h)
+	return data
+}
+
+func (m *MTLSClientAuthMethodsModel) SetValues(h *helpers.Handler, data map[string]any) {
+	objattr.Set(&m.TLSClientAuth, data, "tlsClientAuth", h)
+	objattr.Set(&m.SelfSignedTLSClientAuth, data, "selfSignedTlsClientAuth", h)
+}

--- a/internal/models/project/applications/oidc.go
+++ b/internal/models/project/applications/oidc.go
@@ -2,6 +2,7 @@ package applications
 
 import (
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/boolattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/objattr"
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/strlistattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
@@ -15,22 +16,24 @@ var OIDCAttributes = map[string]schema.Attribute{
 	"logo":        stringattr.Default(""),
 	"disabled":    boolattr.Default(false),
 
-	"login_page_url":       stringattr.Default(""),
-	"claims":               strlistattr.Default(),
-	"force_authentication": boolattr.Default(false),
+	"login_page_url":             stringattr.Default(""),
+	"claims":                     strlistattr.Default(),
+	"force_authentication":       boolattr.Default(false),
+	"mtls_client_auth_methods":   objattr.Optional[MTLSClientAuthMethodsModel](MTLSClientAuthMethodsAttributes),
 }
 
 // Model
 
 type OIDCModel struct {
-	ID                  stringattr.Type  `tfsdk:"id"`
-	Name                stringattr.Type  `tfsdk:"name"`
-	Description         stringattr.Type  `tfsdk:"description"`
-	Logo                stringattr.Type  `tfsdk:"logo"`
-	Disabled            boolattr.Type    `tfsdk:"disabled"`
-	LoginPageURL        stringattr.Type  `tfsdk:"login_page_url"`
-	Claims              strlistattr.Type `tfsdk:"claims"`
-	ForceAuthentication boolattr.Type    `tfsdk:"force_authentication"`
+	ID                    stringattr.Type                        `tfsdk:"id"`
+	Name                  stringattr.Type                        `tfsdk:"name"`
+	Description           stringattr.Type                        `tfsdk:"description"`
+	Logo                  stringattr.Type                        `tfsdk:"logo"`
+	Disabled              boolattr.Type                          `tfsdk:"disabled"`
+	LoginPageURL          stringattr.Type                        `tfsdk:"login_page_url"`
+	Claims                strlistattr.Type                       `tfsdk:"claims"`
+	ForceAuthentication   boolattr.Type                          `tfsdk:"force_authentication"`
+	MTLSClientAuthMethods objattr.Type[MTLSClientAuthMethodsModel] `tfsdk:"mtls_client_auth_methods"`
 }
 
 func (m *OIDCModel) Values(h *helpers.Handler) map[string]any {
@@ -38,6 +41,7 @@ func (m *OIDCModel) Values(h *helpers.Handler) map[string]any {
 	stringattr.Get(m.LoginPageURL, settings, "loginPageUrl")
 	strlistattr.Get(m.Claims, settings, "claims", h)
 	boolattr.Get(m.ForceAuthentication, settings, "forceAuthentication")
+	objattr.Get(m.MTLSClientAuthMethods, settings, "mtlsClientAuthMethods", h)
 
 	data := sharedApplicationData(h, m.ID, m.Name, m.Description, m.Logo, m.Disabled)
 	data["oidc"] = settings
@@ -50,6 +54,7 @@ func (m *OIDCModel) SetValues(h *helpers.Handler, data map[string]any) {
 		stringattr.Nil(&m.LoginPageURL) // XXX reset by the backend on response for now
 		strlistattr.Set(&m.Claims, settings, "claims", h)
 		boolattr.Set(&m.ForceAuthentication, settings, "forceAuthentication")
+		objattr.Set(&m.MTLSClientAuthMethods, settings, "mtlsClientAuthMethods", h)
 	}
 }
 


### PR DESCRIPTION
## Related Issues
Resolves descope/backend#1010

## Description
Add Terraform support for mTLS client authentication on OIDC SSO applications, exposing the `mtls_client_auth_methods` attribute introduced in the backend `mtls` branch (descope/backend#759).

### New file: `internal/models/project/applications/mtls.go`
- `MTLSCredentialModel` — individual cert credential with `id`, `name`, `subject_dn`, `pem`, `thumbprint`; implements `NamedModel` so credentials are matched by name across plan/apply cycles
- `MTLSTLSClientAuthModel` — CA-chain validation (`tls_client_auth`, RFC 8705 §2.1)
- `MTLSSelfSignedTLSClientAuthModel` — exact-cert thumbprint matching (`self_signed_tls_client_auth`, RFC 8705 §2.2)
- `MTLSClientAuthMethodsModel` — top-level container with full `Values`/`SetValues` round-trip

### Updated: `internal/models/project/applications/oidc.go`
Adds `mtls_client_auth_methods` to `OIDCAttributes` and `OIDCModel`, wired to the `mtlsClientAuthMethods` JSON key in the backend snapshot.

### Example HCL
```hcl
applications = {
  oidc_applications = [
    {
      name = "my-app"
      mtls_client_auth_methods = {
        tls_client_auth = {
          credentials = [
            {
              name       = "my-ca"
              subject_dn = "CN=example.com"
              pem        = "-----BEGIN CERTIFICATE-----\n..."
            }
          ]
        }
        self_signed_tls_client_auth = {
          credentials = [
            {
              name = "my-self-signed"
              pem  = "-----BEGIN CERTIFICATE-----\n..."
            }
          ]
        }
      }
    }
  ]
}
```

## Must
- [ ] Acceptance Tests
- [x] Schema Compatibility
- [ ] Documentation Updates