### PR TITLE
Add support for password strength

### DIFF
--- a/docs/raw/project/authentication/password.md
+++ b/docs/raw/project/authentication/password.md
@@ -173,6 +173,16 @@ is not known at validation time.
 
 
 
+enforce_strength
+----------------
+
+- Type: `string`
+- Default: `"none"`
+
+Use zxcvbn to calculate the strength of a given password and enforce a minimum level of strength.
+
+
+
 mask_errors
 -----------
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1405,6 +1405,7 @@ Optional:
 - `disallow_email_match` (Boolean) Whether to reject passwords that match the user's email address or its local-part (the segment before `@`), case-insensitively. The check is skipped if the user's email is not known at validation time.
 - `disallowed_characters` (String) Reject passwords containing any of these characters. Each character in the string is treated as a forbidden literal (e.g., `"'"` to reject single and double quotes).
 - `email_service` (Attributes) Settings related to sending password reset emails as part of the password feature. (see [below for nested schema](#nestedatt--authentication--password--email_service))
+- `enforce_strength` (String) Use zxcvbn to calculate the strength of a given password and enforce a minimum level of strength.
 - `expiration` (Boolean) Whether users are required to change their password periodically.
 - `expiration_weeks` (Number) The number of weeks after which a user's password expires and they need to replace it.
 - `lock` (Boolean) Whether the user account should be locked after a specified number of failed login attempts.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -464,6 +464,7 @@ var docsPassword = map[string]string{
 	"disallow_email_match": "Whether to reject passwords that match the user's email address or its local-part " +
 		"(the segment before `@`), case-insensitively. The check is skipped if the user's email " +
 		"is not known at validation time.",
+	"enforce_strength": "Use zxcvbn to calculate the strength of a given password and enforce a minimum level of strength.",
 	"mask_errors": "Prevents information about user accounts from being revealed in error messages, e.g., " +
 		"whether a user already exists.",
 	"email_service": "Settings related to sending password reset emails as part of the password feature.",

--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -444,6 +444,7 @@ func TestAuthentication(t *testing.T) {
 						temporary_lock = true
 						temporary_lock_attempts = 7
 						temporary_lock_duration = "1 hour"
+						enforce_strength = "strong"
 					}
 					passkeys = {
 						android_fingerprints = [
@@ -459,6 +460,7 @@ func TestAuthentication(t *testing.T) {
 					"temporary_lock":          true,
 					"temporary_lock_attempts": 7,
 					"temporary_lock_duration": "1 hour",
+					"enforce_strength":        "strong",
 				},
 				"authentication.passkeys.android_fingerprints": []string{
 					"AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
@@ -477,9 +479,10 @@ func TestAuthentication(t *testing.T) {
 				}
 			`),
 			Check: p.Check(map[string]any{
-				"authentication.password.any_letter": true,
-				"authentication.password.lowercase":  false,
-				"authentication.password.uppercase":  false,
+				"authentication.password.any_letter":       true,
+				"authentication.password.lowercase":        false,
+				"authentication.password.uppercase":        false,
+				"authentication.password.enforce_strength": "none",
 			}),
 		},
 		resource.TestStep{
@@ -487,13 +490,15 @@ func TestAuthentication(t *testing.T) {
 				authentication = {
 					password = {
 						disallowed_characters = "'\""
-						disallow_email_match  = true
+						disallow_email_match = true
+						enforce_strength = "none"
 					}
 				}
 			`),
 			Check: p.Check(map[string]any{
 				"authentication.password.disallowed_characters": "'\"",
 				"authentication.password.disallow_email_match":  true,
+				"authentication.password.enforce_strength":      "none",
 			}),
 		},
 	)

--- a/internal/models/project/authentication/password.go
+++ b/internal/models/project/authentication/password.go
@@ -9,6 +9,7 @@ import (
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
 	"github.com/descope/terraform-provider-descope/internal/models/project/templates"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
@@ -31,6 +32,7 @@ var PasswordAttributes = map[string]schema.Attribute{
 	"any_letter":              boolattr.Optional(),
 	"disallowed_characters":   stringattr.Optional(),
 	"disallow_email_match":    boolattr.Optional(),
+	"enforce_strength":        stringattr.Default("none", stringvalidator.OneOf("none", "very_weak", "weak", "average", "strong", "very_strong")),
 	"mask_errors":             boolattr.Default(false),
 	"email_service":           objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
 }
@@ -54,6 +56,7 @@ type PasswordModel struct {
 	AnyLetter             boolattr.Type                             `tfsdk:"any_letter"`
 	DisallowedCharacters  stringattr.Type                           `tfsdk:"disallowed_characters"`
 	DisallowEmailMatch    boolattr.Type                             `tfsdk:"disallow_email_match"`
+	EnforceStrength       stringattr.Type                           `tfsdk:"enforce_strength"`
 	MaskErrors            boolattr.Type                             `tfsdk:"mask_errors"`
 	EmailService          objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
 }
@@ -78,6 +81,13 @@ func (m *PasswordModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.Get(m.AnyLetter, data, "anyLetter")
 	stringattr.Get(m.DisallowedCharacters, data, "disallowedCharacters")
 	boolattr.Get(m.DisallowEmailMatch, data, "disallowEmailMatch")
+	if m.EnforceStrength.ValueString() == "none" {
+		data["enablePasswordStrength"] = false
+		data["passwordStrengthScore"] = 0
+	} else {
+		data["enablePasswordStrength"] = true
+		data["passwordStrengthScore"] = strengthScoreFromString(m.EnforceStrength.ValueString())
+	}
 	boolattr.Get(m.MaskErrors, data, "maskError")
 	objattr.Get(m.EmailService, data, helpers.RootKey, h)
 	return data
@@ -102,10 +112,37 @@ func (m *PasswordModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.Set(&m.AnyLetter, data, "anyLetter")
 	stringattr.Set(&m.DisallowedCharacters, data, "disallowedCharacters")
 	boolattr.Set(&m.DisallowEmailMatch, data, "disallowEmailMatch")
+	if enabled, _ := data["enablePasswordStrength"].(bool); !enabled {
+		m.EnforceStrength = stringattr.Value("none")
+	} else {
+		score, _ := data["passwordStrengthScore"].(float64)
+		m.EnforceStrength = stringattr.Value(strengthStringFromScore(int(score)))
+	}
 	boolattr.Set(&m.MaskErrors, data, "maskError")
 	objattr.Set(&m.EmailService, data, helpers.RootKey, h)
 }
 
 func (m *PasswordModel) UpdateReferences(h *helpers.Handler) {
 	objattr.UpdateReferences(&m.EmailService, h)
+}
+
+var strengthLevels = map[string]int{
+	"very_weak":   0,
+	"weak":        1,
+	"average":     2,
+	"strong":      3,
+	"very_strong": 4,
+}
+
+func strengthScoreFromString(s string) int {
+	return strengthLevels[s]
+}
+
+func strengthStringFromScore(n int) string {
+	for name, score := range strengthLevels {
+		if score == n {
+			return name
+		}
+	}
+	return "none"
 }


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/15404

## Description
- Add support for `enforce_strength` attribute in `password` settings.

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
