### PR TITLE
Change client_id attribute to error if value is changed on existing application

### DIFF
--- a/docs/raw/project/applications/oidc.md
+++ b/docs/raw/project/applications/oidc.md
@@ -83,9 +83,9 @@ client_id
 
 - Type: `string`
 
-A dedicated OIDC `client_id` to import for this application. Optional and **immutable** — changing it
-forces the application to be recreated. When omitted, the `client_id` is computed by the server; when
-set, it must be unique within the project. Mirrors the inbound third-party application `client_id`.
+A dedicated OIDC `client_id` to import for this application. When omitted, the `client_id` is computed
+by the server; when set, it must be unique within the project. Can only be set when the application is
+created, and attempting to change it on an existing application will fail.
 
 
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -357,7 +357,7 @@ Optional:
 - `authorization_code_disabled` (Boolean) Disables the `authorization_code` grant type for this application.
 - `claims` (List of String) A list of supported claims. e.g. `sub`, `email`, `exp`.
 - `client_credentials_disabled` (Boolean) Disables the `client_credentials` grant type for this application.
-- `client_id` (String) A dedicated OIDC `client_id` to import for this application. Optional and **immutable** — changing it forces the application to be recreated. When omitted, the `client_id` is computed by the server; when set, it must be unique within the project. Mirrors the inbound third-party application `client_id`.
+- `client_id` (String) A dedicated OIDC `client_id` to import for this application. When omitted, the `client_id` is computed by the server; when set, it must be unique within the project. Can only be set when the application is created, and attempting to change it on an existing application will fail.
 - `client_secret` (String, Sensitive) A dedicated OIDC `client_secret` to import for this application, applied on creation only. When omitted, a secret is generated server-side. The value is sensitive and is not returned on subsequent reads.
 - `client_type` (String) OAuth client confidentiality. One of `""` (default — legacy access-key authentication), `"confidential"` (a dedicated client secret is generated for the app), or `"public"`.
 - `default_audience` (String) Controls the default `aud` claim of tokens issued for this application. One of `"projectId"` (the project ID only), `"clientId"` (the dedicated client ID only), or `""` (default — both). Only applies to modern apps that set a `client_type`; legacy apps always use the project ID, so the empty default leaves their behavior unchanged.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -206,9 +206,9 @@ var docsOIDC = map[string]string{
 	"claims": "A list of supported claims. e.g. `sub`, `email`, `exp`.",
 	"force_authentication": "This configuration overrides the default behavior of the SSO application and forces " +
 		"the user to authenticate via the Descope flow, regardless of the SP's request.",
-	"client_id": "A dedicated OIDC `client_id` to import for this application. Optional and **immutable** — changing it " +
-		"forces the application to be recreated. When omitted, the `client_id` is computed by the server; when " +
-		"set, it must be unique within the project. Mirrors the inbound third-party application `client_id`.",
+	"client_id": "A dedicated OIDC `client_id` to import for this application. When omitted, the `client_id` is computed " +
+		"by the server; when set, it must be unique within the project. Can only be set when the application is " +
+		"created, and attempting to change it on an existing application will fail.",
 	"client_secret": "A dedicated OIDC `client_secret` to import for this application, applied on creation only. When omitted, " +
 		"a secret is generated server-side. The value is sensitive and is not returned on subsequent reads.",
 	"client_type": "OAuth client confidentiality. One of `\"\"` (default — legacy access-key authentication), " +

--- a/internal/models/project/applications/applications.go
+++ b/internal/models/project/applications/applications.go
@@ -11,6 +11,8 @@ import (
 
 var ApplicationsValidator = objattr.NewValidator[ApplicationsModel]("must have a valid applications configuration")
 
+var ApplicationsModifier = objattr.NewModifier[ApplicationsModel]("rejects changes to immutable application fields and maintains application identifiers between plan changes")
+
 var ApplicationsAttributes = map[string]schema.Attribute{
 	"oidc_applications":  listattr.Default[OIDCModel](OIDCAttributes),
 	"saml_applications":  listattr.Default[SAMLModel](SAMLAttributes),
@@ -46,6 +48,20 @@ func (m *ApplicationsModel) Check(h *helpers.Handler) {
 			h.Warn("Both dynamic_configuration and manual_configuration supplied - dynamic configuration will take precedence", "dynamic_configuration and manual_configuration are mutually exclusive. If both given - dynamic takes precedence")
 		}
 	}
+}
+
+func (m *ApplicationsModel) Modify(h *helpers.Handler, state *ApplicationsModel) {
+	for p := range listattr.Iterator(m.OIDCApplications, h) {
+		for s := range listattr.Iterator(state.OIDCApplications, h) {
+			if p.Name.Equal(s.Name) && !p.ClientID.IsUnknown() && !s.ClientID.IsNull() && s.ClientID.ValueString() != "" && p.ClientID.ValueString() != "" && !p.ClientID.Equal(s.ClientID) {
+				h.Error("Immutable Field Changed", "The 'client_id' of OIDC application '%s' cannot be changed after creation, delete the application first to recreate it", s.Name.ValueString())
+			}
+		}
+	}
+
+	listattr.ModifyMatchingNames(h, &m.OIDCApplications, state.OIDCApplications)
+	listattr.ModifyMatchingNames(h, &m.SAMLApplications, state.SAMLApplications)
+	listattr.ModifyMatchingNames(h, &m.WSFedApplications, state.WSFedApplications)
 }
 
 func (m *ApplicationsModel) Validate(h *helpers.Handler) {

--- a/internal/models/project/applications/applications_test.go
+++ b/internal/models/project/applications/applications_test.go
@@ -98,6 +98,76 @@ func TestApplications(t *testing.T) {
 		},
 		resource.TestStep{
 			Config: p.Config(`
+				applications = {
+					oidc_applications = [
+						{
+							name = "foo"
+							description = "bar"
+							logo = "https://example.com/logo.png"
+							disabled = true
+
+							login_page_url = "https://example.com/login"
+							claims = ["email", "name"]
+							force_authentication = true
+
+							client_id = "my-changed-oidc-client"
+							client_secret = "my-custom-oidc-secret-0123456789"
+							client_type = "confidential"
+							approved_redirect_urls = ["https://example.com/cb", "https://example.com/cb2"]
+							authorization_code_disabled = false
+							client_credentials_disabled = true
+							refresh_token_disabled = false
+							jwt_bearer_disabled = true
+							device_code_disabled = true
+							force_pkce = true
+							default_audience = "clientId"
+						}
+					]
+				}
+			`),
+			ExpectError: regexp.MustCompile(`cannot be changed after creation`),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				applications = {
+					oidc_applications = [
+						{
+							name = "foo"
+							description = "bar2"
+							logo = "https://example.com/logo.png"
+							disabled = true
+
+							login_page_url = "https://example.com/login"
+							claims = ["email", "name"]
+							force_authentication = true
+
+							client_id = "my-custom-oidc-client"
+							client_secret = "my-custom-oidc-secret-0123456789"
+							client_type = "confidential"
+							approved_redirect_urls = ["https://example.com/cb", "https://example.com/cb2"]
+							authorization_code_disabled = false
+							client_credentials_disabled = true
+							refresh_token_disabled = false
+							jwt_bearer_disabled = true
+							device_code_disabled = true
+							force_pkce = true
+							default_audience = "clientId"
+						}
+					]
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"applications.oidc_applications.#": 1,
+				"applications.oidc_applications.0": map[string]any{
+					"id":          testacc.AttributeHasPrefix("SA"),
+					"name":        "foo",
+					"description": "bar2",
+					"client_id":   "my-custom-oidc-client",
+				},
+			}),
+		},
+		resource.TestStep{
+			Config: p.Config(`
 			`),
 			Check: p.Check(map[string]any{
 				"applications.oidc_applications.#": 0,

--- a/internal/models/project/applications/oidc.go
+++ b/internal/models/project/applications/oidc.go
@@ -18,34 +18,20 @@ var OIDCAttributes = map[string]schema.Attribute{
 	"logo":        stringattr.Default(""),
 	"disabled":    boolattr.Default(false),
 
-	"login_page_url":       stringattr.Default(""),
-	"claims":               strlistattr.Default(),
-	"force_authentication": boolattr.Default(false),
-
-	// Dedicated client credentials and per-app policy (config-driven; defaults preserve legacy behavior).
-	// client_id/client_secret may import an existing OIDC client; computed/generated server-side when
-	// omitted. Mirrors the inbound third-party app attributes.
-	//
-	// No RequiresReplace here, unlike the standalone descope_inbound_app: oidc_applications is a nested
-	// list inside descope_project and the framework has no element-level replacement, so RequiresReplace
-	// would destroy and recreate the ENTIRE project - every user, tenant and other app in it - just to
-	// add or change one OIDC app. Changes are applied in place via the project update instead.
-	"client_id":     stringattr.Optional(),
-	"client_secret": stringattr.SecretGenerated(true),
-	"client_type":   stringattr.Default("", stringvalidator.OneOf("", "confidential", "public")), // "", "confidential", or "public"
-	// Set (not list): the backend may reorder the URLs, and a list would show perpetual plan diffs -
-	// matching approved_callback_urls (inbound) and acs_allowed_callback_urls (SAML).
-	"approved_redirect_urls": strsetattr.Default(),
-	// Per-app modular grant types (disabled-polarity; all false = all grant types enabled = legacy).
+	"login_page_url":              stringattr.Default(""),
+	"claims":                      strlistattr.Default(),
+	"force_authentication":        boolattr.Default(false),
+	"client_id":                   stringattr.Optional(),
+	"client_secret":               stringattr.SecretGenerated(true),
+	"client_type":                 stringattr.Default("", stringvalidator.OneOf("", "confidential", "public")),
+	"approved_redirect_urls":      strsetattr.Default(),
 	"authorization_code_disabled": boolattr.Default(false),
 	"client_credentials_disabled": boolattr.Default(false),
 	"refresh_token_disabled":      boolattr.Default(false),
 	"jwt_bearer_disabled":         boolattr.Default(false),
 	"device_code_disabled":        boolattr.Default(false),
 	"force_pkce":                  boolattr.Default(false),
-	// Default audience policy for issued tokens (modern apps only): "projectId", "clientId", or "" (both).
-	// Legacy apps (empty client_type) always use the project ID; the empty default preserves that.
-	"default_audience": stringattr.Default("", stringvalidator.OneOf("", "projectId", "clientId")),
+	"default_audience":            stringattr.Default("", stringvalidator.OneOf("", "projectId", "clientId")),
 
 	"permissions": listattr.Default[SSOAppPermissionModel](SSOAppPermissionAttributes),
 	"roles":       listattr.Default[SSOAppRoleModel](SSOAppRoleAttributes),
@@ -54,26 +40,26 @@ var OIDCAttributes = map[string]schema.Attribute{
 // Model
 
 type OIDCModel struct {
-	ID                  stringattr.Type  `tfsdk:"id"`
-	Name                stringattr.Type  `tfsdk:"name"`
-	Description         stringattr.Type  `tfsdk:"description"`
-	Logo                stringattr.Type  `tfsdk:"logo"`
-	Disabled            boolattr.Type    `tfsdk:"disabled"`
-	LoginPageURL        stringattr.Type  `tfsdk:"login_page_url"`
-	Claims              strlistattr.Type `tfsdk:"claims"`
-	ForceAuthentication boolattr.Type    `tfsdk:"force_authentication"`
+	ID          stringattr.Type `tfsdk:"id"`
+	Name        stringattr.Type `tfsdk:"name"`
+	Description stringattr.Type `tfsdk:"description"`
+	Logo        stringattr.Type `tfsdk:"logo"`
+	Disabled    boolattr.Type   `tfsdk:"disabled"`
 
-	ClientID                  stringattr.Type `tfsdk:"client_id"`
-	ClientSecret              stringattr.Type `tfsdk:"client_secret"`
-	ClientType                stringattr.Type `tfsdk:"client_type"`
-	ApprovedRedirectURLs      strsetattr.Type `tfsdk:"approved_redirect_urls"`
-	AuthorizationCodeDisabled boolattr.Type   `tfsdk:"authorization_code_disabled"`
-	ClientCredentialsDisabled boolattr.Type   `tfsdk:"client_credentials_disabled"`
-	RefreshTokenDisabled      boolattr.Type   `tfsdk:"refresh_token_disabled"`
-	JWTBearerDisabled         boolattr.Type   `tfsdk:"jwt_bearer_disabled"`
-	DeviceCodeDisabled        boolattr.Type   `tfsdk:"device_code_disabled"`
-	ForcePkce                 boolattr.Type   `tfsdk:"force_pkce"`
-	DefaultAudience           stringattr.Type `tfsdk:"default_audience"`
+	LoginPageURL              stringattr.Type  `tfsdk:"login_page_url"`
+	Claims                    strlistattr.Type `tfsdk:"claims"`
+	ForceAuthentication       boolattr.Type    `tfsdk:"force_authentication"`
+	ClientID                  stringattr.Type  `tfsdk:"client_id"`
+	ClientSecret              stringattr.Type  `tfsdk:"client_secret"`
+	ClientType                stringattr.Type  `tfsdk:"client_type"`
+	ApprovedRedirectURLs      strsetattr.Type  `tfsdk:"approved_redirect_urls"`
+	AuthorizationCodeDisabled boolattr.Type    `tfsdk:"authorization_code_disabled"`
+	ClientCredentialsDisabled boolattr.Type    `tfsdk:"client_credentials_disabled"`
+	RefreshTokenDisabled      boolattr.Type    `tfsdk:"refresh_token_disabled"`
+	JWTBearerDisabled         boolattr.Type    `tfsdk:"jwt_bearer_disabled"`
+	DeviceCodeDisabled        boolattr.Type    `tfsdk:"device_code_disabled"`
+	ForcePkce                 boolattr.Type    `tfsdk:"force_pkce"`
+	DefaultAudience           stringattr.Type  `tfsdk:"default_audience"`
 
 	Permissions listattr.Type[SSOAppPermissionModel] `tfsdk:"permissions"`
 	Roles       listattr.Type[SSOAppRoleModel]       `tfsdk:"roles"`

--- a/internal/models/project/applications/saml.go
+++ b/internal/models/project/applications/saml.go
@@ -36,11 +36,12 @@ var SAMLAttributes = map[string]schema.Attribute{
 // Model
 
 type SAMLModel struct {
-	ID                        stringattr.Type                         `tfsdk:"id"`
-	Name                      stringattr.Type                         `tfsdk:"name"`
-	Description               stringattr.Type                         `tfsdk:"description"`
-	Logo                      stringattr.Type                         `tfsdk:"logo"`
-	Disabled                  boolattr.Type                           `tfsdk:"disabled"`
+	ID          stringattr.Type `tfsdk:"id"`
+	Name        stringattr.Type `tfsdk:"name"`
+	Description stringattr.Type `tfsdk:"description"`
+	Logo        stringattr.Type `tfsdk:"logo"`
+	Disabled    boolattr.Type   `tfsdk:"disabled"`
+
 	LoginPageURL              stringattr.Type                         `tfsdk:"login_page_url"`
 	DynamicConfiguration      objattr.Type[DynamicConfigurationModel] `tfsdk:"dynamic_configuration"`
 	ManualConfiguration       objattr.Type[ManualConfigurationModel]  `tfsdk:"manual_configuration"`

--- a/internal/models/project/applications/wsfed.go
+++ b/internal/models/project/applications/wsfed.go
@@ -33,11 +33,12 @@ var WSFedAttributes = map[string]schema.Attribute{
 // Model
 
 type WSFedModel struct {
-	ID                       stringattr.Type                      `tfsdk:"id"`
-	Name                     stringattr.Type                      `tfsdk:"name"`
-	Description              stringattr.Type                      `tfsdk:"description"`
-	Logo                     stringattr.Type                      `tfsdk:"logo"`
-	Disabled                 boolattr.Type                        `tfsdk:"disabled"`
+	ID          stringattr.Type `tfsdk:"id"`
+	Name        stringattr.Type `tfsdk:"name"`
+	Description stringattr.Type `tfsdk:"description"`
+	Logo        stringattr.Type `tfsdk:"logo"`
+	Disabled    boolattr.Type   `tfsdk:"disabled"`
+
 	Realm                    stringattr.Type                      `tfsdk:"realm"`
 	ReplyURL                 stringattr.Type                      `tfsdk:"reply_url"`
 	ReplyAllowedCallbackURLs strsetattr.Type                      `tfsdk:"reply_allowed_callback_urls"`

--- a/internal/models/project/project.go
+++ b/internal/models/project/project.go
@@ -33,7 +33,7 @@ var ProjectAttributes = map[string]schema.Attribute{
 	"authorization":    objattr.Default[authorization.AuthorizationModel](nil, authorization.AuthorizationAttributes, authorization.AuthorizationModifier, authorization.AuthorizationValidator),
 	"attributes":       objattr.Default[attributes.AttributesModel](nil, attributes.AttributesAttributes),
 	"connectors":       objattr.Default[connectors.ConnectorsModel](nil, connectors.ConnectorsAttributes, connectors.ConnectorsModifier, connectors.ConnectorsValidator),
-	"applications":     objattr.Default[applications.ApplicationsModel](nil, applications.ApplicationsAttributes, applications.ApplicationsValidator),
+	"applications":     objattr.Default[applications.ApplicationsModel](nil, applications.ApplicationsAttributes, applications.ApplicationsModifier, applications.ApplicationsValidator),
 	"jwt_templates":    objattr.Optional[jwttemplates.JWTTemplatesModel](jwttemplates.JWTTemplatesAttributes, jwttemplates.JWTTemplatesValidator),
 	"styles":           objattr.Default[flows.StylesModel](nil, flows.StylesAttributes),
 	"flows":            mapattr.Default[flows.FlowModel](nil, flows.FlowAttributes, flows.FlowIDValidator),


### PR DESCRIPTION

## Related Issues
Fixes https://github.com/descope/etc/issues/16729

## Description
- Prevent the `client_id` attribute from being changed after an application is created.

## Must
- [X] Acceptance Tests
- [X] Schema Compatibility
- [X] Documentation Updates
