### PR TITLE
Re-enable SCIM connector acceptance test

### DIFF
--- a/internal/models/project/connectors/shared_test.go
+++ b/internal/models/project/connectors/shared_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestSCIMConnector(t *testing.T) {
-	t.Skip("Temporarily skipping SCIM test because of backend problems")
 	p := testacc.Project(t)
 	testacc.Run(t,
 		resource.TestStep{


### PR DESCRIPTION
## Summary
- Drops the `t.Skip("Temporarily skipping SCIM test because of backend problems")` guard on `TestSCIMConnector`.
- The underlying backend problem — `SCIMIntegration.GetAppID` reading through the Redis cache reader before it had caught up on a freshly-provisioned project — is fixed in descope/backend#1744.

## Test plan
- [ ] Land after descope/backend#1744 is deployed
- [ ] `TF_ACC=1 go test -run TestSCIMConnector ./internal/models/project/connectors/...` passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)