### PR TITLE
feat(connectors): assign HTTP connectors to a Descope engine

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -2631,6 +2631,7 @@ Optional:
 - `aws_secret_access_key` (String, Sensitive) The secret AWS access key.
 - `aws_service` (String) The AWS service to target, e.g. `lambda`, `execute-api`, `s3`, etc.
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The identifier of the Descope engine that should run this connector. Leave empty to run the connector locally.
 - `headers` (Map of String) The headers to send with the request
 - `hmac_secret` (String, Sensitive) HMAC is a method for message signing with a symmetrical key. This secret will be used to sign the base64 encoded payload, and the resulting signature will be sent in the `x-descope-webhook-s256` header. The receiving service should use this secret to verify the integrity and authenticity of the payload by checking the provided signature
 - `include_headers_in_context` (Boolean) The connector response context will also include the headers and status code. The context will have a "body" attribute, a "headers" attribute, and a "statusCode" attribute. See more details in the help guide

--- a/internal/models/project/connectors/engine_internal_test.go
+++ b/internal/models/project/connectors/engine_internal_test.go
@@ -1,0 +1,41 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConnectorEngine verifies that the engine_id attribute round-trips through the
+// top-level executor fields the backend expects for connectors assigned to an engine.
+func TestConnectorEngine(t *testing.T) {
+	// assigning an engine writes the top-level executor fields
+	data := map[string]any{}
+	setConnectorEngine(data, stringattr.Value("CIEngine123"))
+	assert.Equal(t, "engine", data["executorType"])
+	assert.Equal(t, "CIEngine123", data["executorId"])
+
+	// reading them back recovers the engine id
+	var engineID stringattr.Type
+	getConnectorEngine(data, &engineID)
+	assert.Equal(t, "CIEngine123", engineID.ValueString())
+
+	// an empty engine id leaves the connector local: no executor fields are emitted
+	local := map[string]any{}
+	setConnectorEngine(local, stringattr.Value(""))
+	_, hasType := local["executorType"]
+	_, hasID := local["executorId"]
+	assert.False(t, hasType)
+	assert.False(t, hasID)
+
+	// reading a locally executed connector yields an empty engine id
+	var localEngineID stringattr.Type
+	getConnectorEngine(map[string]any{"executorType": "local"}, &localEngineID)
+	assert.Equal(t, "", localEngineID.ValueString())
+
+	// a connector object with no executor fields also yields an empty engine id
+	var missingEngineID stringattr.Type
+	getConnectorEngine(map[string]any{}, &missingEngineID)
+	assert.Equal(t, "", missingEngineID.ValueString())
+}

--- a/internal/models/project/connectors/http.go
+++ b/internal/models/project/connectors/http.go
@@ -41,6 +41,7 @@ var HTTPAttributes = map[string]schema.Attribute{
 	"insecure":                   boolattr.Default(false),
 	"include_headers_in_context": boolattr.Default(false),
 	"use_static_ips":             boolattr.Default(false),
+	"engine_id":                  stringattr.Default(""),
 }
 
 // Model
@@ -69,17 +70,20 @@ type HTTPModel struct {
 	Insecure                boolattr.Type                    `tfsdk:"insecure"`
 	IncludeHeadersInContext boolattr.Type                    `tfsdk:"include_headers_in_context"`
 	UseStaticIPs            boolattr.Type                    `tfsdk:"use_static_ips"`
+	EngineID                stringattr.Type                  `tfsdk:"engine_id"`
 }
 
 func (m *HTTPModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "http"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *HTTPModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/shared.go
+++ b/internal/models/project/connectors/shared.go
@@ -41,6 +41,34 @@ func setConnectorValues(id, name, description *stringattr.Type, data map[string]
 	stringattr.Set(description, data, "description")
 }
 
+// Engine assignment
+
+// executorTypeEngine marks a connector as running on a specific engine rather than locally.
+// The backend keeps the assignment in the top-level executorType/executorId fields of the
+// connector and defaults to a local executor when they are unset, so an empty engine id
+// simply leaves the connector running locally.
+const executorTypeEngine = "engine"
+
+// setConnectorEngine writes the engine assignment onto the connector object as the top-level
+// executor fields the backend expects. An empty engine id emits nothing, so the connector
+// keeps running locally.
+func setConnectorEngine(data map[string]any, engineID stringattr.Type) {
+	if id := engineID.ValueString(); id != "" {
+		data["executorType"] = executorTypeEngine
+		data["executorId"] = id
+	}
+}
+
+// getConnectorEngine reads the top-level executor fields back into the engine_id attribute,
+// leaving it empty for connectors that run locally.
+func getConnectorEngine(data map[string]any, engineID *stringattr.Type) {
+	if data["executorType"] == executorTypeEngine {
+		stringattr.Set(engineID, data, "executorId")
+	} else {
+		*engineID = stringattr.Value("")
+	}
+}
+
 // Connector Utils
 
 func addConnectorReferences[T any, M helpers.NamedModel[T]](h *helpers.Handler, key string, connectors listattr.Type[T]) {

--- a/internal/models/project/connectors/shared_test.go
+++ b/internal/models/project/connectors/shared_test.go
@@ -136,3 +136,36 @@ func TestConnectorsShared(t *testing.T) {
 		},
 	)
 }
+
+func TestHTTPConnectorEngine(t *testing.T) {
+	// Assigning a connector to an engine requires a running engineservice to resolve the
+	// engine, which is not deployed in the acceptance-test environment. The engine_id
+	// round-trip is covered by the unit test in engine_internal_test.go.
+	t.Skip("Temporarily skipping HTTP connector engine test: engineservice is not deployed in the acceptance-test environment")
+
+	p := testacc.Project(t)
+	testacc.Run(t,
+		resource.TestStep{
+			Config: p.Config(`
+				connectors = {
+					"http": [
+						{
+							name      = "My HTTP Connector"
+							base_url  = "https://example.com"
+							engine_id = "CIEngineExample"
+						}
+					]
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"connectors.http.#": 1,
+				"connectors.http.0": map[string]any{
+					"id":        testacc.AttributeHasPrefix("CI"),
+					"name":      "My HTTP Connector",
+					"base_url":  "https://example.com",
+					"engine_id": "CIEngineExample",
+				},
+			}),
+		},
+	)
+}

--- a/tools/terragen/conngen/connector.go
+++ b/tools/terragen/conngen/connector.go
@@ -41,6 +41,13 @@ func (c *Connector) SupportsStaticIPs() bool {
 	return c.Extra["supportStaticIps"] == true
 }
 
+// SupportsEngine reports whether the connector can be assigned to a Descope engine via the
+// engine_id attribute. Engine execution is currently limited to the general purpose HTTP
+// connector, so the gate is keyed on the connector id rather than external template metadata.
+func (c *Connector) SupportsEngine() bool {
+	return c.ID == "http"
+}
+
 func (c *Connector) StructName() string {
 	return c.naming.GetName("connector", c.ID, "struct", c.defaultStructName())
 }

--- a/tools/terragen/conngen/connector.gotmpl
+++ b/tools/terragen/conngen/connector.gotmpl
@@ -42,6 +42,9 @@ var {{.StructName}}Attributes = map[string]schema.Attribute{
     {{ range .Fields }}
     "{{.AttributeName}}": {{.AttributeType}},
     {{- end }}
+    {{- if .SupportsEngine }}
+    "engine_id": stringattr.Default(""),
+    {{- end }}
 }
 
 // Model
@@ -54,21 +57,30 @@ type {{.StructName}}Model struct {
     {{ range .Fields }}
     {{.StructName}} {{.StructType}} `tfsdk:"{{.AttributeName}}"`
     {{- end }}
+    {{- if .SupportsEngine }}
+    EngineID stringattr.Type `tfsdk:"engine_id"`
+    {{- end }}
 }
 
 func (m *{{.StructName}}Model) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "{{.ID}}"
 	data["configuration"] = m.ConfigurationValues(h)
+	{{- if .SupportsEngine }}
+	setConnectorEngine(data, m.EngineID)
+	{{- end }}
 	return data
 }
 
 func (m *{{.StructName}}Model) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	{{- if .SupportsEngine }}
+	getConnectorEngine(data, &m.EngineID)
+	{{- end }}
 	{{- if gt (len .Fields) 0 }}
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
-	}	
+	}
 	{{- end }}
 }
 


### PR DESCRIPTION
## What

Adds an `engine_id` attribute to the **HTTP** connector so a connector can be assigned to a Descope engine declaratively:

```hcl
connectors = {
  http = [{
    name      = "My HTTP Connector"
    base_url  = "https://example.com"
    engine_id = descope_engine.my_engine.id
  }]
}
```

Leaving `engine_id` empty runs the connector locally (the backend default).

## How

The backend already persists engine assignment in the top-level `executorType` / `executorId` fields of the connector, and those round-trip through the project snapshot (`convertObject` maps them straight to/from the proto on import/export). So this is a **provider-only** change — no backend change required.

- `shared.go` — `setConnectorEngine` / `getConnectorEngine` helpers translate `engine_id` ↔ top-level `executorType="engine"`/`executorId`.
- `conngen` — `SupportsEngine()` gate (HTTP only, keyed on connector id) + `connector.gotmpl` blocks, so `make terragen` reproduces the generated `http.go`.
- `http.go` — generated `engine_id` attribute (hand-applied here; the connector templates needed by `make terragen` aren't available in this environment — maintainers should regenerate to confirm parity).
- Unit test covers the `engine_id` round-trip. A full acceptance test is included but **skipped**, since engineservice isn't deployed in the acceptance-test environment (same as the `descope_engine` resource test).

## Testing

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./internal/models/project/connectors/` passes (unit test runs; acceptance tests skip)

fixes descope/etc#16838

🤖 Generated with [Claude Code](https://claude.com/claude-code)