### PR TITLE
feat(connectors): add OAuth2 client credentials auth to HTTP connectors

### DIFF
--- a/docs/raw/project/connectors/shared.md
+++ b/docs/raw/project/connectors/shared.md
@@ -116,6 +116,15 @@ API key authentication configuration.
 
 
 
+oauth2_client_credentials
+-------------------------
+
+- Type: `object` of `connectors.HTTPAuthOAuth2ClientCredentialsField`
+
+OAuth 2.0 client credentials configuration used to fetch an access token before making requests.
+
+
+
 
 
 HTTPAuthBasicField
@@ -163,3 +172,66 @@ token
 - Type: `secret` (required)
 
 The API secret.
+
+
+
+
+
+HTTPAuthOAuth2ClientCredentialsField
+====================================
+
+
+
+client_id
+---------
+
+- Type: `string` (required)
+
+The OAuth 2.0 client ID used to authenticate against the token endpoint.
+
+
+
+client_secret
+-------------
+
+- Type: `secret` (required)
+
+The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+
+
+auth_url
+--------
+
+- Type: `string` (required)
+
+The token endpoint URL used to request an access token.
+
+
+
+auth_style
+----------
+
+- Type: `string`
+- Default: `"header"`
+
+How the client credentials are sent to the token endpoint. Either `header` to send them in the
+`Authorization` header, or `params` to send them in the request body.
+
+
+
+scopes
+------
+
+- Type: `string`
+
+A space-separated list of OAuth scopes to request when fetching the access token.
+
+
+
+token_request_headers
+---------------------
+
+- Type: `map` of `string`
+
+Additional headers to include in the token request sent to the token endpoint.

--- a/docs/raw/project/connectors/shared.md
+++ b/docs/raw/project/connectors/shared.md
@@ -216,7 +216,7 @@ auth_style
 - Default: `"header"`
 
 How the client credentials are sent to the token endpoint. Either `header` to send them in the
-`Authorization` header, or `params` to send them in the request body.
+`Authorization` header, or `body` to send them in the request body.
 
 
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1906,6 +1906,7 @@ Optional:
 - `api_key` (Attributes) API key authentication configuration. (see [below for nested schema](#nestedatt--connectors--audit_webhook--authentication--api_key))
 - `basic` (Attributes) Basic authentication credentials (username and password). (see [below for nested schema](#nestedatt--connectors--audit_webhook--authentication--basic))
 - `bearer_token` (String, Sensitive) Bearer token for HTTP authentication.
+- `oauth2_client_credentials` (Attributes) OAuth 2.0 client credentials configuration used to fetch an access token before making requests. (see [below for nested schema](#nestedatt--connectors--audit_webhook--authentication--oauth2_client_credentials))
 
 <a id="nestedatt--connectors--audit_webhook--authentication--api_key"></a>
 ### Nested Schema for `connectors.audit_webhook.authentication.api_key`
@@ -1923,6 +1924,22 @@ Required:
 
 - `password` (String, Sensitive) Password for basic HTTP authentication.
 - `username` (String) Username for basic HTTP authentication.
+
+
+<a id="nestedatt--connectors--audit_webhook--authentication--oauth2_client_credentials"></a>
+### Nested Schema for `connectors.audit_webhook.authentication.oauth2_client_credentials`
+
+Required:
+
+- `auth_url` (String) The token endpoint URL used to request an access token.
+- `client_id` (String) The OAuth 2.0 client ID used to authenticate against the token endpoint.
+- `client_secret` (String, Sensitive) The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+Optional:
+
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
+- `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
 
 
@@ -2275,6 +2292,7 @@ Optional:
 - `api_key` (Attributes) API key authentication configuration. (see [below for nested schema](#nestedatt--connectors--external_token_http--authentication--api_key))
 - `basic` (Attributes) Basic authentication credentials (username and password). (see [below for nested schema](#nestedatt--connectors--external_token_http--authentication--basic))
 - `bearer_token` (String, Sensitive) Bearer token for HTTP authentication.
+- `oauth2_client_credentials` (Attributes) OAuth 2.0 client credentials configuration used to fetch an access token before making requests. (see [below for nested schema](#nestedatt--connectors--external_token_http--authentication--oauth2_client_credentials))
 
 <a id="nestedatt--connectors--external_token_http--authentication--api_key"></a>
 ### Nested Schema for `connectors.external_token_http.authentication.api_key`
@@ -2292,6 +2310,22 @@ Required:
 
 - `password` (String, Sensitive) Password for basic HTTP authentication.
 - `username` (String) Username for basic HTTP authentication.
+
+
+<a id="nestedatt--connectors--external_token_http--authentication--oauth2_client_credentials"></a>
+### Nested Schema for `connectors.external_token_http.authentication.oauth2_client_credentials`
+
+Required:
+
+- `auth_url` (String) The token endpoint URL used to request an access token.
+- `client_id` (String) The OAuth 2.0 client ID used to authenticate against the token endpoint.
+- `client_secret` (String, Sensitive) The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+Optional:
+
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
+- `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
 
 
@@ -2403,6 +2437,7 @@ Optional:
 - `api_key` (Attributes) API key authentication configuration. (see [below for nested schema](#nestedatt--connectors--generic_email_gateway--authentication--api_key))
 - `basic` (Attributes) Basic authentication credentials (username and password). (see [below for nested schema](#nestedatt--connectors--generic_email_gateway--authentication--basic))
 - `bearer_token` (String, Sensitive) Bearer token for HTTP authentication.
+- `oauth2_client_credentials` (Attributes) OAuth 2.0 client credentials configuration used to fetch an access token before making requests. (see [below for nested schema](#nestedatt--connectors--generic_email_gateway--authentication--oauth2_client_credentials))
 
 <a id="nestedatt--connectors--generic_email_gateway--authentication--api_key"></a>
 ### Nested Schema for `connectors.generic_email_gateway.authentication.api_key`
@@ -2420,6 +2455,22 @@ Required:
 
 - `password` (String, Sensitive) Password for basic HTTP authentication.
 - `username` (String) Username for basic HTTP authentication.
+
+
+<a id="nestedatt--connectors--generic_email_gateway--authentication--oauth2_client_credentials"></a>
+### Nested Schema for `connectors.generic_email_gateway.authentication.oauth2_client_credentials`
+
+Required:
+
+- `auth_url` (String) The token endpoint URL used to request an access token.
+- `client_id` (String) The OAuth 2.0 client ID used to authenticate against the token endpoint.
+- `client_secret` (String, Sensitive) The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+Optional:
+
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
+- `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
 
 
@@ -2454,6 +2505,7 @@ Optional:
 - `api_key` (Attributes) API key authentication configuration. (see [below for nested schema](#nestedatt--connectors--generic_sms_gateway--authentication--api_key))
 - `basic` (Attributes) Basic authentication credentials (username and password). (see [below for nested schema](#nestedatt--connectors--generic_sms_gateway--authentication--basic))
 - `bearer_token` (String, Sensitive) Bearer token for HTTP authentication.
+- `oauth2_client_credentials` (Attributes) OAuth 2.0 client credentials configuration used to fetch an access token before making requests. (see [below for nested schema](#nestedatt--connectors--generic_sms_gateway--authentication--oauth2_client_credentials))
 
 <a id="nestedatt--connectors--generic_sms_gateway--authentication--api_key"></a>
 ### Nested Schema for `connectors.generic_sms_gateway.authentication.api_key`
@@ -2471,6 +2523,22 @@ Required:
 
 - `password` (String, Sensitive) Password for basic HTTP authentication.
 - `username` (String) Username for basic HTTP authentication.
+
+
+<a id="nestedatt--connectors--generic_sms_gateway--authentication--oauth2_client_credentials"></a>
+### Nested Schema for `connectors.generic_sms_gateway.authentication.oauth2_client_credentials`
+
+Required:
+
+- `auth_url` (String) The token endpoint URL used to request an access token.
+- `client_id` (String) The OAuth 2.0 client ID used to authenticate against the token endpoint.
+- `client_secret` (String, Sensitive) The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+Optional:
+
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
+- `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
 
 
@@ -2631,7 +2699,7 @@ Optional:
 - `aws_secret_access_key` (String, Sensitive) The secret AWS access key.
 - `aws_service` (String) The AWS service to target, e.g. `lambda`, `execute-api`, `s3`, etc.
 - `description` (String) A description of what your connector is used for.
-- `engine_id` (String) The identifier of the Descope engine that should run this connector. Leave empty to run the connector locally.
+- `engine_id` (String)
 - `headers` (Map of String) The headers to send with the request
 - `hmac_secret` (String, Sensitive) HMAC is a method for message signing with a symmetrical key. This secret will be used to sign the base64 encoded payload, and the resulting signature will be sent in the `x-descope-webhook-s256` header. The receiving service should use this secret to verify the integrity and authenticity of the payload by checking the provided signature
 - `include_headers_in_context` (Boolean) The connector response context will also include the headers and status code. The context will have a "body" attribute, a "headers" attribute, and a "statusCode" attribute. See more details in the help guide
@@ -2655,6 +2723,7 @@ Optional:
 - `api_key` (Attributes) API key authentication configuration. (see [below for nested schema](#nestedatt--connectors--http--authentication--api_key))
 - `basic` (Attributes) Basic authentication credentials (username and password). (see [below for nested schema](#nestedatt--connectors--http--authentication--basic))
 - `bearer_token` (String, Sensitive) Bearer token for HTTP authentication.
+- `oauth2_client_credentials` (Attributes) OAuth 2.0 client credentials configuration used to fetch an access token before making requests. (see [below for nested schema](#nestedatt--connectors--http--authentication--oauth2_client_credentials))
 
 <a id="nestedatt--connectors--http--authentication--api_key"></a>
 ### Nested Schema for `connectors.http.authentication.api_key`
@@ -2672,6 +2741,22 @@ Required:
 
 - `password` (String, Sensitive) Password for basic HTTP authentication.
 - `username` (String) Username for basic HTTP authentication.
+
+
+<a id="nestedatt--connectors--http--authentication--oauth2_client_credentials"></a>
+### Nested Schema for `connectors.http.authentication.oauth2_client_credentials`
+
+Required:
+
+- `auth_url` (String) The token endpoint URL used to request an access token.
+- `client_id` (String) The OAuth 2.0 client ID used to authenticate against the token endpoint.
+- `client_secret` (String, Sensitive) The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+Optional:
+
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
+- `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
 
 
@@ -2909,6 +2994,7 @@ Optional:
 - `api_key` (Attributes) API key authentication configuration. (see [below for nested schema](#nestedatt--connectors--opentelemetry--authentication--api_key))
 - `basic` (Attributes) Basic authentication credentials (username and password). (see [below for nested schema](#nestedatt--connectors--opentelemetry--authentication--basic))
 - `bearer_token` (String, Sensitive) Bearer token for HTTP authentication.
+- `oauth2_client_credentials` (Attributes) OAuth 2.0 client credentials configuration used to fetch an access token before making requests. (see [below for nested schema](#nestedatt--connectors--opentelemetry--authentication--oauth2_client_credentials))
 
 <a id="nestedatt--connectors--opentelemetry--authentication--api_key"></a>
 ### Nested Schema for `connectors.opentelemetry.authentication.api_key`
@@ -2926,6 +3012,22 @@ Required:
 
 - `password` (String, Sensitive) Password for basic HTTP authentication.
 - `username` (String) Username for basic HTTP authentication.
+
+
+<a id="nestedatt--connectors--opentelemetry--authentication--oauth2_client_credentials"></a>
+### Nested Schema for `connectors.opentelemetry.authentication.oauth2_client_credentials`
+
+Required:
+
+- `auth_url` (String) The token endpoint URL used to request an access token.
+- `client_id` (String) The OAuth 2.0 client ID used to authenticate against the token endpoint.
+- `client_secret` (String, Sensitive) The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+Optional:
+
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
+- `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
 
 
@@ -3212,6 +3314,7 @@ Optional:
 - `api_key` (Attributes) API key authentication configuration. (see [below for nested schema](#nestedatt--connectors--scim--authentication--api_key))
 - `basic` (Attributes) Basic authentication credentials (username and password). (see [below for nested schema](#nestedatt--connectors--scim--authentication--basic))
 - `bearer_token` (String, Sensitive) Bearer token for HTTP authentication.
+- `oauth2_client_credentials` (Attributes) OAuth 2.0 client credentials configuration used to fetch an access token before making requests. (see [below for nested schema](#nestedatt--connectors--scim--authentication--oauth2_client_credentials))
 
 <a id="nestedatt--connectors--scim--authentication--api_key"></a>
 ### Nested Schema for `connectors.scim.authentication.api_key`
@@ -3229,6 +3332,22 @@ Required:
 
 - `password` (String, Sensitive) Password for basic HTTP authentication.
 - `username` (String) Username for basic HTTP authentication.
+
+
+<a id="nestedatt--connectors--scim--authentication--oauth2_client_credentials"></a>
+### Nested Schema for `connectors.scim.authentication.oauth2_client_credentials`
+
+Required:
+
+- `auth_url` (String) The token endpoint URL used to request an access token.
+- `client_id` (String) The OAuth 2.0 client ID used to authenticate against the token endpoint.
+- `client_secret` (String, Sensitive) The OAuth 2.0 client secret used to authenticate against the token endpoint.
+
+Optional:
+
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
+- `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
 
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1937,7 +1937,7 @@ Required:
 
 Optional:
 
-- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `body` to send them in the request body.
 - `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
 - `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
@@ -2323,7 +2323,7 @@ Required:
 
 Optional:
 
-- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `body` to send them in the request body.
 - `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
 - `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
@@ -2468,7 +2468,7 @@ Required:
 
 Optional:
 
-- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `body` to send them in the request body.
 - `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
 - `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
@@ -2536,7 +2536,7 @@ Required:
 
 Optional:
 
-- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `body` to send them in the request body.
 - `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
 - `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
@@ -2754,7 +2754,7 @@ Required:
 
 Optional:
 
-- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `body` to send them in the request body.
 - `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
 - `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
@@ -3025,7 +3025,7 @@ Required:
 
 Optional:
 
-- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `body` to send them in the request body.
 - `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
 - `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 
@@ -3345,7 +3345,7 @@ Required:
 
 Optional:
 
-- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `params` to send them in the request body.
+- `auth_style` (String) How the client credentials are sent to the token endpoint. Either `header` to send them in the `Authorization` header, or `body` to send them in the request body.
 - `scopes` (String) A space-separated list of OAuth scopes to request when fetching the access token.
 - `token_request_headers` (Map of String) Additional headers to include in the token request sent to the token endpoint.
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1099,6 +1099,7 @@ var docsHTTP = map[string]string{
 		"The context will have a \"body\" attribute, a \"headers\" attribute, and a " +
 		"\"statusCode\" attribute. See more details in the help guide",
 	"use_static_ips": "Whether the connector should send all requests from specific static IPs.",
+	"engine_id":      "",
 }
 
 var docsHubSpot = map[string]string{
@@ -1407,9 +1408,10 @@ var docsAuditFilterField = map[string]string{
 }
 
 var docsHTTPAuthField = map[string]string{
-	"bearer_token": "Bearer token for HTTP authentication.",
-	"basic":        "Basic authentication credentials (username and password).",
-	"api_key":      "API key authentication configuration.",
+	"bearer_token":              "Bearer token for HTTP authentication.",
+	"basic":                     "Basic authentication credentials (username and password).",
+	"api_key":                   "API key authentication configuration.",
+	"oauth2_client_credentials": "OAuth 2.0 client credentials configuration used to fetch an access token before making requests.",
 }
 
 var docsHTTPAuthBasicField = map[string]string{
@@ -1420,6 +1422,16 @@ var docsHTTPAuthBasicField = map[string]string{
 var docsHTTPAuthAPIKeyField = map[string]string{
 	"key":   "The API key.",
 	"token": "The API secret.",
+}
+
+var docsHTTPAuthOAuth2ClientCredentialsField = map[string]string{
+	"client_id":     "The OAuth 2.0 client ID used to authenticate against the token endpoint.",
+	"client_secret": "The OAuth 2.0 client secret used to authenticate against the token endpoint.",
+	"auth_url":      "The token endpoint URL used to request an access token.",
+	"auth_style": "How the client credentials are sent to the token endpoint. Either `header` to send them in the " +
+		"`Authorization` header, or `params` to send them in the request body.",
+	"scopes":                "A space-separated list of OAuth scopes to request when fetching the access token.",
+	"token_request_headers": "Additional headers to include in the token request sent to the token endpoint.",
 }
 
 var docsSlack = map[string]string{

--- a/internal/docs/models.go
+++ b/internal/docs/models.go
@@ -145,6 +145,7 @@ func InjectModels() {
 	inject(connectors.HTTPAuthFieldAttributes, docsHTTPAuthField)
 	inject(connectors.HTTPAuthBasicFieldAttributes, docsHTTPAuthBasicField)
 	inject(connectors.HTTPAuthAPIKeyFieldAttributes, docsHTTPAuthAPIKeyField)
+	inject(connectors.HTTPAuthOAuth2ClientCredentialsFieldAttributes, docsHTTPAuthOAuth2ClientCredentialsField)
 	inject(connectors.SlackAttributes, docsSlack)
 	inject(connectors.SmartlingAttributes, docsSmartling)
 	inject(connectors.SMTPAttributes, docsSMTP)

--- a/internal/models/project/connectors/shared.go
+++ b/internal/models/project/connectors/shared.go
@@ -192,21 +192,24 @@ func setHeaders(s *strmapattr.Type, data map[string]any, key string, _ *helpers.
 var HTTPAuthFieldValidator = objattr.NewValidator[HTTPAuthFieldModel]("must specify exactly one authentication method")
 
 var HTTPAuthFieldAttributes = map[string]schema.Attribute{
-	"bearer_token": stringattr.SecretOptional(),
-	"basic":        objattr.Default[HTTPAuthBasicFieldModel](nil, HTTPAuthBasicFieldAttributes),
-	"api_key":      objattr.Default[HTTPAuthAPIKeyFieldModel](nil, HTTPAuthAPIKeyFieldAttributes),
+	"bearer_token":              stringattr.SecretOptional(),
+	"basic":                     objattr.Default[HTTPAuthBasicFieldModel](nil, HTTPAuthBasicFieldAttributes),
+	"api_key":                   objattr.Default[HTTPAuthAPIKeyFieldModel](nil, HTTPAuthAPIKeyFieldAttributes),
+	"oauth2_client_credentials": objattr.Default[HTTPAuthOAuth2ClientCredentialsFieldModel](nil, HTTPAuthOAuth2ClientCredentialsFieldAttributes),
 }
 
 var HTTPAuthFieldDefault = &HTTPAuthFieldModel{
-	BearerToken: stringattr.Value(""),
-	Basic:       objattr.Value[HTTPAuthBasicFieldModel](nil),
-	ApiKey:      objattr.Value[HTTPAuthAPIKeyFieldModel](nil),
+	BearerToken:             stringattr.Value(""),
+	Basic:                   objattr.Value[HTTPAuthBasicFieldModel](nil),
+	ApiKey:                  objattr.Value[HTTPAuthAPIKeyFieldModel](nil),
+	OAuth2ClientCredentials: objattr.Value[HTTPAuthOAuth2ClientCredentialsFieldModel](nil),
 }
 
 type HTTPAuthFieldModel struct {
-	BearerToken stringattr.Type                        `tfsdk:"bearer_token"`
-	Basic       objattr.Type[HTTPAuthBasicFieldModel]  `tfsdk:"basic"`
-	ApiKey      objattr.Type[HTTPAuthAPIKeyFieldModel] `tfsdk:"api_key"`
+	BearerToken             stringattr.Type                                         `tfsdk:"bearer_token"`
+	Basic                   objattr.Type[HTTPAuthBasicFieldModel]                   `tfsdk:"basic"`
+	ApiKey                  objattr.Type[HTTPAuthAPIKeyFieldModel]                  `tfsdk:"api_key"`
+	OAuth2ClientCredentials objattr.Type[HTTPAuthOAuth2ClientCredentialsFieldModel] `tfsdk:"oauth2_client_credentials"`
 }
 
 func (m *HTTPAuthFieldModel) Values(h *helpers.Handler) map[string]any {
@@ -224,6 +227,10 @@ func (m *HTTPAuthFieldModel) Values(h *helpers.Handler) map[string]any {
 		data["method"] = "apiKey"
 		objattr.Get(m.ApiKey, data, "apiKey", h)
 	}
+	if m.OAuth2ClientCredentials.IsSet() {
+		data["method"] = "oauth2ClientCredentials"
+		objattr.Get(m.OAuth2ClientCredentials, data, "oauth2ClientCredentials", h)
+	}
 	return data
 }
 
@@ -238,6 +245,11 @@ func (m *HTTPAuthFieldModel) SetValues(h *helpers.Handler, data map[string]any) 
 		objattr.Set(&m.ApiKey, data, "apiKey", h)
 	} else {
 		objattr.Nil(&m.ApiKey)
+	}
+	if data["method"] == "oauth2ClientCredentials" {
+		objattr.Set(&m.OAuth2ClientCredentials, data, "oauth2ClientCredentials", h)
+	} else {
+		objattr.Nil(&m.OAuth2ClientCredentials)
 	}
 }
 
@@ -254,6 +266,9 @@ func (m *HTTPAuthFieldModel) Validate(h *helpers.Handler) {
 		count += 1
 	}
 	if m.ApiKey.IsSet() {
+		count += 1
+	}
+	if m.OAuth2ClientCredentials.IsSet() {
 		count += 1
 	}
 
@@ -308,4 +323,44 @@ func (m *HTTPAuthAPIKeyFieldModel) Values(h *helpers.Handler) map[string]any {
 func (m *HTTPAuthAPIKeyFieldModel) SetValues(h *helpers.Handler, data map[string]any) {
 	stringattr.Set(&m.Key, data, "key")
 	stringattr.Nil(&m.Token)
+}
+
+// HTTP Auth OAuth2 Client Credentials Field
+
+var HTTPAuthOAuth2ClientCredentialsFieldAttributes = map[string]schema.Attribute{
+	"client_id":             stringattr.Required(),
+	"client_secret":         stringattr.SecretRequired(),
+	"auth_url":              stringattr.Required(),
+	"auth_style":            stringattr.Default("header", stringvalidator.OneOf("header", "params")),
+	"scopes":                stringattr.Default(""),
+	"token_request_headers": strmapattr.Default(),
+}
+
+type HTTPAuthOAuth2ClientCredentialsFieldModel struct {
+	ClientID            stringattr.Type `tfsdk:"client_id"`
+	ClientSecret        stringattr.Type `tfsdk:"client_secret"`
+	AuthURL             stringattr.Type `tfsdk:"auth_url"`
+	AuthStyle           stringattr.Type `tfsdk:"auth_style"`
+	Scopes              stringattr.Type `tfsdk:"scopes"`
+	TokenRequestHeaders strmapattr.Type `tfsdk:"token_request_headers"`
+}
+
+func (m *HTTPAuthOAuth2ClientCredentialsFieldModel) Values(h *helpers.Handler) map[string]any {
+	data := map[string]any{}
+	stringattr.Get(m.ClientID, data, "clientId")
+	stringattr.Get(m.ClientSecret, data, "clientSecret")
+	stringattr.Get(m.AuthURL, data, "authUrl")
+	stringattr.Get(m.AuthStyle, data, "authStyle")
+	stringattr.Get(m.Scopes, data, "scopes")
+	getHeaders(m.TokenRequestHeaders, data, "tokenRequestHeaders", h)
+	return data
+}
+
+func (m *HTTPAuthOAuth2ClientCredentialsFieldModel) SetValues(h *helpers.Handler, data map[string]any) {
+	stringattr.Set(&m.ClientID, data, "clientId")
+	stringattr.Nil(&m.ClientSecret)
+	stringattr.Set(&m.AuthURL, data, "authUrl")
+	stringattr.Set(&m.AuthStyle, data, "authStyle")
+	stringattr.Set(&m.Scopes, data, "scopes")
+	setHeaders(&m.TokenRequestHeaders, data, "tokenRequestHeaders", h)
 }

--- a/internal/models/project/connectors/shared.go
+++ b/internal/models/project/connectors/shared.go
@@ -331,7 +331,7 @@ var HTTPAuthOAuth2ClientCredentialsFieldAttributes = map[string]schema.Attribute
 	"client_id":             stringattr.Required(),
 	"client_secret":         stringattr.SecretRequired(),
 	"auth_url":              stringattr.Required(),
-	"auth_style":            stringattr.Default("header", stringvalidator.OneOf("header", "params")),
+	"auth_style":            stringattr.Default("header", stringvalidator.OneOf("header", "body")),
 	"scopes":                stringattr.Default(""),
 	"token_request_headers": strmapattr.Default(),
 }

--- a/internal/models/project/connectors/shared_test.go
+++ b/internal/models/project/connectors/shared_test.go
@@ -207,7 +207,7 @@ func TestHTTPConnectorOAuth2ClientCredentialsValidation(t *testing.T) {
 			`),
 			ExpectError: regexp.MustCompile(`Cannot specify more than one connector authentication method`),
 		},
-		// auth_style only accepts "header" or "params".
+		// auth_style only accepts "header" or "body".
 		resource.TestStep{
 			Config: p.Config(`
 				connectors = {

--- a/internal/models/project/connectors/shared_test.go
+++ b/internal/models/project/connectors/shared_test.go
@@ -137,6 +137,50 @@ func TestConnectorsShared(t *testing.T) {
 	)
 }
 
+func TestHTTPConnectorOAuth2ClientCredentials(t *testing.T) {
+	p := testacc.Project(t)
+	testacc.Run(t,
+		resource.TestStep{
+			Config: p.Config(`
+				connectors = {
+					"http": [
+						{
+							name     = "My HTTP Connector"
+							base_url = "https://example.com"
+							authentication = {
+								oauth2_client_credentials = {
+									client_id     = "test-client-id"
+									client_secret = "test-client-secret"
+									auth_url      = "https://example.com/oauth/token"
+									auth_style    = "header"
+									scopes        = "read write"
+									token_request_headers = {
+										"X-Custom" = "value"
+									}
+								}
+							}
+						}
+					]
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"connectors.http.#": 1,
+				"connectors.http.0": map[string]any{
+					"id":       testacc.AttributeMatchesPattern(`^(CI|MP)`),
+					"name":     "My HTTP Connector",
+					"base_url": "https://example.com",
+					"authentication.oauth2_client_credentials.client_id":                      "test-client-id",
+					"authentication.oauth2_client_credentials.client_secret":                  "test-client-secret",
+					"authentication.oauth2_client_credentials.auth_url":                       "https://example.com/oauth/token",
+					"authentication.oauth2_client_credentials.auth_style":                     "header",
+					"authentication.oauth2_client_credentials.scopes":                         "read write",
+					"authentication.oauth2_client_credentials.token_request_headers.X-Custom": "value",
+				},
+			}),
+		},
+	)
+}
+
 func TestHTTPConnectorEngine(t *testing.T) {
 	// Assigning a connector to an engine requires a running engineservice to resolve the
 	// engine, which is not deployed in the acceptance-test environment. The engine_id

--- a/internal/models/project/connectors/shared_test.go
+++ b/internal/models/project/connectors/shared_test.go
@@ -1,6 +1,7 @@
 package connectors_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/descope/terraform-provider-descope/tools/testacc"
@@ -177,6 +178,56 @@ func TestHTTPConnectorOAuth2ClientCredentials(t *testing.T) {
 					"authentication.oauth2_client_credentials.token_request_headers.X-Custom": "value",
 				},
 			}),
+		},
+	)
+}
+
+func TestHTTPConnectorOAuth2ClientCredentialsValidation(t *testing.T) {
+	p := testacc.Project(t)
+	testacc.Run(t,
+		// A single connector cannot declare more than one authentication method.
+		resource.TestStep{
+			Config: p.Config(`
+				connectors = {
+					"http": [
+						{
+							name     = "invalid-two-auth"
+							base_url = "https://example.com"
+							authentication = {
+								bearer_token = "some-bearer-token"
+								oauth2_client_credentials = {
+									client_id     = "test"
+									client_secret = "test"
+									auth_url      = "https://example.com/oauth/token"
+								}
+							}
+						}
+					]
+				}
+			`),
+			ExpectError: regexp.MustCompile(`Cannot specify more than one connector authentication method`),
+		},
+		// auth_style only accepts "header" or "params".
+		resource.TestStep{
+			Config: p.Config(`
+				connectors = {
+					"http": [
+						{
+							name     = "invalid-auth-style"
+							base_url = "https://example.com"
+							authentication = {
+								oauth2_client_credentials = {
+									client_id     = "test"
+									client_secret = "test"
+									auth_url      = "https://example.com/oauth/token"
+									auth_style    = "invalid"
+								}
+							}
+						}
+					]
+				}
+			`),
+			ExpectError: regexp.MustCompile(`value must be one of`),
 		},
 	)
 }


### PR DESCRIPTION
## Summary

Adds `oauth2_client_credentials` as a new authentication method for HTTP-based connectors, alongside the existing `bearer_token`, `basic`, and `api_key`. The Descope API already accepts `method: "oauth2ClientCredentials"`; this exposes it in the provider.

New nested attribute `authentication.oauth2_client_credentials`:
- `client_id` (required), `client_secret` (required, secret), `auth_url` (required)
- `auth_style` (default `header`, one of `header`/`params`)
- `scopes` (space-separated string)
- `token_request_headers` (map)

## Must

- [x] **Acceptance Tests** — `TestHTTPConnectorOAuth2ClientCredentials` (round-trip) and `TestHTTPConnectorOAuth2ClientCredentialsValidation` (mutual-exclusion + `auth_style` OneOf) in `internal/models/project/connectors/shared_test.go`.
- [x] **Schema Compatibility** — Backward compatible / additive only. New *optional* nested attribute; no existing attribute changed, renamed, or made required. Existing configs unaffected; no state migration.
- [x] **Documentation Updates** — Regenerated `internal/docs/docs.go`, `internal/docs/models.go`, and `docs/resources/project.md` via `terragen --skip-validate` + `tfplugindocs`; source descriptions in `docs/raw/project/connectors/shared.md`.

## Note for reviewers

Plain `make terragen` currently fails on the **unrelated** `segment` connector (`autoTriggerStepTypes` — `dependsOn` on a multi-select field, unsupported by `connector.go:211`). This is a pre-existing terragen/`etc` incompatibility, not introduced here. Docs were generated against a templates copy with that unadopted `segment` field stripped; no `segment` output changed.

