### PR TITLE
feat(connectors): add IAM role-based auth to AWS SNS connector

### DIFF
--- a/docs/raw/project/connectors/sns.md
+++ b/docs/raw/project/connectors/sns.md
@@ -4,10 +4,20 @@ SNS
 
 
 
+auth_type
+---------
+
+- Type: `string`
+- Default: `"credentials"`
+
+The authentication type to use.
+
+
+
 access_key_id
 -------------
 
-- Type: `secret` (required)
+- Type: `secret`
 
 AWS Access key ID.
 
@@ -16,9 +26,27 @@ AWS Access key ID.
 secret
 ------
 
-- Type: `secret` (required)
+- Type: `secret`
 
 AWS Secret Access Key.
+
+
+
+role_arn
+--------
+
+- Type: `string`
+
+The Amazon Resource Name (ARN) of the role to assume.
+
+
+
+external_id
+-----------
+
+- Type: `string`
+
+The external ID to use when assuming the role.
 
 
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -3460,18 +3460,21 @@ Required:
 
 Required:
 
-- `access_key_id` (String, Sensitive) AWS Access key ID.
 - `name` (String) A custom name for your connector.
 - `region` (String) AWS region to send requests to (e.g. `us-west-2`).
-- `secret` (String, Sensitive) AWS Secret Access Key.
 
 Optional:
 
+- `access_key_id` (String, Sensitive) AWS Access key ID.
+- `auth_type` (String)
 - `description` (String) A description of what your connector is used for.
 - `endpoint` (String) An optional endpoint URL (hostname only or fully qualified URI).
 - `entity_id` (String) The entity ID or principal entity (PE) ID for sending text messages to recipients in India.
+- `external_id` (String)
 - `organization_number` (String, Deprecated) Use the `origination_number` attribute instead.
 - `origination_number` (String) An optional phone number from which the text messages are going to be sent. Make sure it is registered properly in your server.
+- `role_arn` (String)
+- `secret` (String, Sensitive) AWS Secret Access Key.
 - `sender_id` (String) The name of the sender from which the text message is going to be sent (see SNS documentation regarding acceptable IDs and supported regions/countries).
 - `template_id` (String) The template for sending text messages to recipients in India. The template ID must be associated with the sender ID.
 

--- a/internal/models/project/connectors/sns.go
+++ b/internal/models/project/connectors/sns.go
@@ -4,6 +4,7 @@ import (
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/objattr"
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
 	"github.com/descope/terraform-provider-descope/internal/models/helpers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
@@ -14,8 +15,11 @@ var SNSAttributes = map[string]schema.Attribute{
 	"name":        stringattr.Required(stringattr.StandardLenValidator),
 	"description": stringattr.Default(""),
 
-	"access_key_id":      stringattr.SecretRequired(),
-	"secret":             stringattr.SecretRequired(),
+	"auth_type":          stringattr.Default("credentials", stringvalidator.OneOf("credentials", "assumeRole")),
+	"access_key_id":      stringattr.SecretOptional(),
+	"secret":             stringattr.SecretOptional(),
+	"role_arn":           stringattr.Default(""),
+	"external_id":        stringattr.Default(""),
 	"region":             stringattr.Required(),
 	"endpoint":           stringattr.Default(""),
 	"origination_number": stringattr.Default(""),
@@ -34,8 +38,11 @@ type SNSModel struct {
 	Name        stringattr.Type `tfsdk:"name"`
 	Description stringattr.Type `tfsdk:"description"`
 
+	AuthType          stringattr.Type `tfsdk:"auth_type"`
 	AccessKeyId       stringattr.Type `tfsdk:"access_key_id"`
 	Secret            stringattr.Type `tfsdk:"secret"`
+	RoleARN           stringattr.Type `tfsdk:"role_arn"`
+	ExternalID        stringattr.Type `tfsdk:"external_id"`
 	Region            stringattr.Type `tfsdk:"region"`
 	Endpoint          stringattr.Type `tfsdk:"endpoint"`
 	OriginationNumber stringattr.Type `tfsdk:"origination_number"`
@@ -65,14 +72,46 @@ func (m *SNSModel) Validate(h *helpers.Handler) {
 	if m.OrganizationNumber.ValueString() != "" && m.OriginationNumber.ValueString() != "" {
 		h.Conflict("The organization_number field has been renamed to origination_number, please use only origination_number going forward")
 	}
+
+	isCredentials := m.AuthType.ValueString() == "credentials" || m.AuthType.ValueString() == ""
+	isAssumeRole := m.AuthType.ValueString() == "assumeRole"
+
+	if isCredentials && m.AccessKeyId.ValueString() == "" && !m.AccessKeyId.IsUnknown() {
+		h.Conflict("The access_key_id field is required when auth_type is set to 'credentials'")
+	}
+	if isCredentials && m.Secret.ValueString() == "" && !m.Secret.IsUnknown() {
+		h.Conflict("The secret field is required when auth_type is set to 'credentials'")
+	}
+	if !isCredentials && m.AccessKeyId.ValueString() != "" {
+		h.Conflict("The access_key_id field can only be used when auth_type is set to 'credentials'")
+	}
+	if !isCredentials && m.Secret.ValueString() != "" {
+		h.Conflict("The secret field can only be used when auth_type is set to 'credentials'")
+	}
+
+	if isAssumeRole && m.RoleARN.ValueString() == "" && !m.RoleARN.IsUnknown() {
+		h.Conflict("The role_arn field is required when auth_type is set to 'assumeRole'")
+	}
+	if isAssumeRole && m.ExternalID.ValueString() == "" && !m.ExternalID.IsUnknown() {
+		h.Conflict("The external_id field is required when auth_type is set to 'assumeRole'")
+	}
+	if !isAssumeRole && m.RoleARN.ValueString() != "" {
+		h.Conflict("The role_arn field can only be used when auth_type is set to 'assumeRole'")
+	}
+	if !isAssumeRole && m.ExternalID.ValueString() != "" {
+		h.Conflict("The external_id field can only be used when auth_type is set to 'assumeRole'")
+	}
 }
 
 // Configuration
 
 func (m *SNSModel) ConfigurationValues(h *helpers.Handler) map[string]any {
 	c := map[string]any{}
+	stringattr.Get(m.AuthType, c, "authType")
 	stringattr.Get(m.AccessKeyId, c, "accessKeyId")
 	stringattr.Get(m.Secret, c, "secretAccessKey")
+	stringattr.Get(m.RoleARN, c, "roleArn")
+	stringattr.Get(m.ExternalID, c, "externalId")
 	stringattr.Get(m.Region, c, "awsSNSRegion")
 	stringattr.Get(m.Endpoint, c, "awsEndpoint")
 	stringattr.Get(m.OriginationNumber, c, "originationNumber")
@@ -88,8 +127,11 @@ func (m *SNSModel) ConfigurationValues(h *helpers.Handler) map[string]any {
 }
 
 func (m *SNSModel) SetConfigurationValues(c map[string]any, h *helpers.Handler) {
+	stringattr.Set(&m.AuthType, c, "authType")
 	stringattr.Nil(&m.AccessKeyId)
 	stringattr.Nil(&m.Secret)
+	stringattr.Set(&m.RoleARN, c, "roleArn")
+	stringattr.Set(&m.ExternalID, c, "externalId")
 	stringattr.Set(&m.Region, c, "awsSNSRegion")
 	stringattr.Set(&m.Endpoint, c, "awsEndpoint")
 	if m.OrganizationNumber.ValueString() == "" { // Don't overwrite when deprecated field is set


### PR DESCRIPTION
Mirror the SES connector: add an auth_type toggle (credentials vs assumeRole) with role_arn and external_id, relax access_key_id/secret to optional, and add conflict validation. Regenerated connector docs.

Relates to descope/etc#16855
