### PR TITLE
feat(inbound-app): add force_dpop attribute

### DIFF
--- a/docs/raw/inboundapp/inboundapp.md
+++ b/docs/raw/inboundapp/inboundapp.md
@@ -117,6 +117,15 @@ When enabled, all of the user's tenants, roles, and permissions will always be i
 
 
 
+force_dpop
+----------
+
+- Type: `bool`
+
+Require clients to use DPoP (Demonstrating Proof of Possession), binding access tokens to a key held by the client so a stolen token cannot be used by anyone else.
+
+
+
 default_audience
 ----------------
 

--- a/docs/resources/inbound_app.md
+++ b/docs/resources/inbound_app.md
@@ -31,6 +31,7 @@ description: |-
 - `default_audience` (String) The default `aud` claim to include in tokens issued for this app. Use `projectId` to set the project ID as the audience, `clientId` to set the app's client ID, or leave empty to include both.
 - `description` (String) A description for the inbound app.
 - `force_add_all_authorization_info` (Boolean) When enabled, all of the user's tenants, roles, and permissions will always be included in issued tokens.
+- `force_dpop` (Boolean) Require clients to use DPoP (Demonstrating Proof of Possession), binding access tokens to a key held by the client so a stolen token cannot be used by anyone else.
 - `force_pkce` (Boolean) When enabled, the authorization code flow requires PKCE in addition to the normal client authentication. A confidential client must then present both its client secret and a valid PKCE `code_verifier`. Public clients always use PKCE regardless of this setting.
 - `login_page_url` (String) The Flow Hosting URL.
 - `logo_url` (String) A URL to the inbound app's logo image.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -99,6 +99,7 @@ var docsInboundApp = map[string]string{
 	"audience_whitelist": "A set of allowed custom `aud` claim values that the inbound app can request via the `resource` " +
 		"parameter, per RFC 8707.",
 	"force_add_all_authorization_info": "When enabled, all of the user's tenants, roles, and permissions will always be included in issued tokens.",
+	"force_dpop":                       "Require clients to use DPoP (Demonstrating Proof of Possession), binding access tokens to a key held by the client so a stolen token cannot be used by anyone else.",
 	"default_audience": "The default `aud` claim to include in tokens issued for this app. Use `projectId` to set the project ID " +
 		"as the audience, `clientId` to set the app's client ID, or leave empty to include both.",
 	"non_confidential_client": "Whether this is a public (non-confidential) client that does not use a client secret. Changing this " +

--- a/internal/models/inboundapp/inboundapp.go
+++ b/internal/models/inboundapp/inboundapp.go
@@ -27,6 +27,7 @@ var InboundAppAttributes = map[string]schema.Attribute{
 	"session_settings":                 objattr.Optional[SessionSettingsModel](SessionSettingsAttributes, SessionSettingsValidator),
 	"audience_whitelist":               strsetattr.Default(),
 	"force_add_all_authorization_info": boolattr.Default(false),
+	"force_dpop":                       boolattr.Default(false),
 	"default_audience":                 stringattr.Default("", stringvalidator.OneOf("", "projectId", "clientId")), // XXX maybe switch to set
 	"non_confidential_client":          boolattr.Default(false, boolplanmodifier.RequiresReplace()),
 	"client_id":                        stringattr.Optional(stringplanmodifier.RequiresReplace()),
@@ -52,6 +53,7 @@ type InboundAppModel struct {
 	SessionSettings              objattr.Type[SessionSettingsModel]   `tfsdk:"session_settings"`
 	AudienceWhitelist            strsetattr.Type                      `tfsdk:"audience_whitelist"`
 	ForceAddAllAuthorizationInfo boolattr.Type                        `tfsdk:"force_add_all_authorization_info"`
+	ForceDpop                    boolattr.Type                        `tfsdk:"force_dpop"`
 	DefaultAudience              stringattr.Type                      `tfsdk:"default_audience"`
 	NonConfidentialClient        boolattr.Type                        `tfsdk:"non_confidential_client"`
 	ClientId                     stringattr.Type                      `tfsdk:"client_id"`
@@ -72,6 +74,7 @@ func (m *InboundAppModel) Values(h *helpers.Handler) map[string]any {
 	objattr.Get(m.SessionSettings, data, "sessionSettings", h)
 	strsetattr.Get(m.AudienceWhitelist, data, "audienceWhitelist", h)
 	boolattr.Get(m.ForceAddAllAuthorizationInfo, data, "forceAddAllAuthorizationInfo")
+	boolattr.Get(m.ForceDpop, data, "forceDpop")
 	stringattr.Get(m.DefaultAudience, data, "defaultAudience")
 	boolattr.Get(m.NonConfidentialClient, data, "nonConfidentialClient")
 	stringattr.Get(m.ClientId, data, "clientId")
@@ -92,6 +95,7 @@ func (m *InboundAppModel) SetValues(h *helpers.Handler, data map[string]any) {
 	objattr.Set(&m.SessionSettings, data, "sessionSettings", h)
 	strsetattr.Set(&m.AudienceWhitelist, data, "audienceWhitelist", h)
 	boolattr.Set(&m.ForceAddAllAuthorizationInfo, data, "forceAddAllAuthorizationInfo")
+	boolattr.Set(&m.ForceDpop, data, "forceDpop")
 	stringattr.Set(&m.DefaultAudience, data, "defaultAudience")
 	boolattr.Set(&m.NonConfidentialClient, data, "nonConfidentialClient")
 	stringattr.Set(&m.ClientId, data, "clientId")

--- a/internal/models/inboundapp/inboundapp_test.go
+++ b/internal/models/inboundapp/inboundapp_test.go
@@ -31,6 +31,7 @@ func TestInboundApp(t *testing.T) {
 				"connections_scopes.#":             "0",
 				"audience_whitelist.#":             "0",
 				"force_add_all_authorization_info": "false",
+				"force_dpop":                       "false",
 				"default_audience":                 "",
 			}),
 		},


### PR DESCRIPTION
## What
Adds a `force_dpop` boolean to the `descope_inbound_app` resource, exposing the backend per-app **Require DPoP** (RFC 9449) enforcement toggle.

- Plain boolean, no `RequiresReplace` (mirrors `force_add_all_authorization_info`).
- Maps to the management-API key `forceDpop`.

## Testing
- `go build ./...` and `go test ./internal/models/inboundapp/...` pass.

Part of descope/etc#17053. Backend + Console siblings linked in a follow-up comment.