### PR TITLE
feat(connectors): add engine_id support to all engine-enabled connectors

### DIFF
--- a/docs/raw/project/settings/settings.md
+++ b/docs/raw/project/settings/settings.md
@@ -54,6 +54,17 @@ sessions, and MFA state.
 
 
 
+allow_auth_hosting_iframe_embedding
+-----------------------------------
+
+- Type: `bool`
+
+When enabled, Descope-hosted flows can be displayed within an iframe on
+your website. This modifies the security headers that typically prevent the page from
+being embedded.
+
+
+
 refresh_token_rotation
 ----------------------
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1882,6 +1882,7 @@ Optional:
 - `audit_filters` (Attributes List) Specify which events will be sent to the external audit service (including tenant selection). (see [below for nested schema](#nestedatt--connectors--audit_webhook--audit_filters))
 - `authentication` (Attributes) Authentication Information (see [below for nested schema](#nestedatt--connectors--audit_webhook--authentication))
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `headers` (Map of String) The headers to send with the request
 - `hmac_secret` (String, Sensitive) HMAC is a method for message signing with a symmetrical key. This secret will be used to sign the payload, and the resulting signature will be sent in the `x-descope-webhook-s256` header. The receiving service should use this secret to verify the integrity and authenticity of the payload by checking the provided signature
 - `insecure` (Boolean) Will ignore certificate errors raised by the client
@@ -1962,6 +1963,7 @@ Optional:
 - `audit_filters` (Attributes List) Specify which events will be sent to the external audit service (including tenant selection). (see [below for nested schema](#nestedatt--connectors--aws_s3--audit_filters))
 - `auth_type` (String) The authentication type to use.
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `external_id` (String) The external ID to use when assuming the role.
 - `mask_pii` (Boolean) Whether to mask personally identifiable information in the logs.
 - `role_arn` (String) The Amazon Resource Name (ARN) of the role to assume.
@@ -1996,6 +1998,7 @@ Optional:
 - `access_key_id` (String) AWS access key ID.
 - `auth_type` (String) The authentication type to use.
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `external_id` (String) The external ID to use when assuming the role.
 - `role_arn` (String) The Amazon Resource Name (ARN) of the role to assume.
 - `secret_access_key` (String, Sensitive) AWS secret access key.
@@ -2019,6 +2022,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `session_token` (String, Sensitive) (Optional) A security or session token to use with these credentials. Usually present for temporary credentials.
 
 Read-Only:
@@ -2148,6 +2152,7 @@ Optional:
 - `audit_enabled` (Boolean) Whether to enable streaming of audit events.
 - `audit_filters` (Attributes List) Specify which events will be sent to the external audit service (including tenant selection). (see [below for nested schema](#nestedatt--connectors--datadog--audit_filters))
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `mask_pii` (Boolean) Whether to mask personally identifiable information in the logs.
 - `site` (String) The Datadog site to send logs to. Default is `datadoghq.com`. European, free tier and other customers should set their site accordingly.
 - `source` (String) An optional custom source to use for log entries sent to Datadog. This can be used to differentiate between environments (e.g. `production`, `staging`). If left empty, the default Descope source will be used.
@@ -2381,6 +2386,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 
 Read-Only:
 
@@ -2558,6 +2564,7 @@ Optional:
 - `audit_enabled` (Boolean) Whether to enable streaming of audit events.
 - `audit_filters` (Attributes List) Specify which events will be sent to the external audit service (including tenant selection). (see [below for nested schema](#nestedatt--connectors--google_cloud_logging--audit_filters))
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `troubleshoot_log_enabled` (Boolean) Whether to send troubleshooting events.
 
 Read-Only:
@@ -2587,6 +2594,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 
 Read-Only:
 
@@ -2676,6 +2684,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 
 Read-Only:
 
@@ -2701,7 +2710,7 @@ Optional:
 - `aws_secret_access_key` (String, Sensitive) The secret AWS access key.
 - `aws_service` (String) The AWS service to target, e.g. `lambda`, `execute-api`, `s3`, etc.
 - `description` (String) A description of what your connector is used for.
-- `engine_id` (String)
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `headers` (Map of String) The headers to send with the request
 - `hmac_secret` (String, Sensitive) HMAC is a method for message signing with a symmetrical key. This secret will be used to sign the base64 encoded payload, and the resulting signature will be sent in the `x-descope-webhook-s256` header. The receiving service should use this secret to verify the integrity and authenticity of the payload by checking the provided signature
 - `include_headers_in_context` (Boolean) The connector response context will also include the headers and status code. The context will have a "body" attribute, a "headers" attribute, and a "statusCode" attribute. See more details in the help guide
@@ -3078,6 +3087,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 
 Read-Only:
 
@@ -3161,6 +3171,7 @@ Optional:
 - `base_url` (String) The base URL used to load the reCAPTCHA Enterprise scripts. Select recaptcha.net when google.com is unavailable in your users' region. Restricting this to the official Google domains prevents loading scripts from untrusted hosts.
 - `bot_threshold` (Number) The bot threshold is used to determine whether the request is a bot or a human. The score ranges between 0 and 1, where 1 is a human interaction and 0 is a bot. If the score is below this threshold, the request is considered a bot.
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `override_assessment` (Boolean) Override the default assessment model. Note: Overriding assessment is intended for automated testing and should not be utilized in production environments.
 
 Read-Only:
@@ -3202,6 +3213,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 
 Read-Only:
 
@@ -3240,6 +3252,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 
 Read-Only:
 
@@ -3260,6 +3273,7 @@ Optional:
 
 - `account_id` (String) Account identifier, or MID, of the target business unit.
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `scope` (String) Space-separated list of data-access permissions for your connector.
 
 Read-Only:
@@ -3457,6 +3471,7 @@ Required:
 Optional:
 
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 
 Read-Only:
 
@@ -3555,6 +3570,7 @@ Optional:
 - `audit_table` (String) The table to write audit events to. Defaults to `DESCOPE_AUDIT_LOGS`.
 - `database` (String) The Snowflake database to use. Defaults to `DESCOPE_EXPORT_DB`.
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `mask_pii` (Boolean) Whether to mask personally identifiable information in the logs.
 - `min_flush_interval_minutes` (Number) The minimum time between writes to Snowflake, in minutes. When set, events are accumulated and written in a single batch at most once per interval, which lets the warehouse auto-suspend between writes and reduces cost. Set to 0 (or leave empty) to write events according to the default Descope cycle.
 - `schema` (String) The schema within the database. Defaults to `PUBLIC`.
@@ -3587,14 +3603,14 @@ Required:
 Optional:
 
 - `access_key_id` (String, Sensitive) AWS Access key ID.
-- `auth_type` (String)
+- `auth_type` (String) The authentication type to use.
 - `description` (String) A description of what your connector is used for.
 - `endpoint` (String) An optional endpoint URL (hostname only or fully qualified URI).
 - `entity_id` (String) The entity ID or principal entity (PE) ID for sending text messages to recipients in India.
-- `external_id` (String)
+- `external_id` (String) The external ID to use when assuming the role.
 - `organization_number` (String, Deprecated) Use the `origination_number` attribute instead.
 - `origination_number` (String) An optional phone number from which the text messages are going to be sent. Make sure it is registered properly in your server.
-- `role_arn` (String)
+- `role_arn` (String) The Amazon Resource Name (ARN) of the role to assume.
 - `secret` (String, Sensitive) AWS Secret Access Key.
 - `sender_id` (String) The name of the sender from which the text message is going to be sent (see SNS documentation regarding acceptable IDs and supported regions/countries).
 - `template_id` (String) The template for sending text messages to recipients in India. The template ID must be associated with the sender ID.
@@ -3618,6 +3634,7 @@ Optional:
 - `audit_enabled` (Boolean) Whether to enable streaming of audit events.
 - `audit_filters` (Attributes List) Specify which events will be sent to the external audit service (including tenant selection). (see [below for nested schema](#nestedatt--connectors--splunk--audit_filters))
 - `description` (String) A description of what your connector is used for.
+- `engine_id` (String) The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend.
 - `index` (String) An optional index to use for all sent events
 - `troubleshoot_log_enabled` (Boolean) Whether to send troubleshooting events.
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -644,6 +644,8 @@ var docsAuditWebhook = map[string]string{
 	"insecure": "Will ignore certificate errors raised by the client",
 	"audit_filters": "Specify which events will be sent to the external audit service (including " +
 		"tenant selection).",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsAWSS3 = map[string]string{
@@ -661,6 +663,8 @@ var docsAWSS3 = map[string]string{
 		"tenant selection).",
 	"troubleshoot_log_enabled": "Whether to send troubleshooting events.",
 	"mask_pii":                 "Whether to mask personally identifiable information in the logs.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsAWSSESEmailValidation = map[string]string{
@@ -674,6 +678,8 @@ var docsAWSSESEmailValidation = map[string]string{
 	"role_arn":    "The Amazon Resource Name (ARN) of the role to assume.",
 	"external_id": "The external ID to use when assuming the role.",
 	"region":      "The AWS region to which this client will send requests. (e.g. us-east-1.)",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsAWSTranslate = map[string]string{
@@ -684,6 +690,8 @@ var docsAWSTranslate = map[string]string{
 	"session_token": "(Optional) A security or session token to use with these credentials. Usually " +
 		"present for temporary credentials.",
 	"region": "The AWS region to which this client will send requests. (e.g. us-east-1.)",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsBitsight = map[string]string{
@@ -872,6 +880,8 @@ var docsDatadog = map[string]string{
 		"tenant selection).",
 	"troubleshoot_log_enabled": "Whether to send troubleshooting events.",
 	"mask_pii":                 "Whether to mask personally identifiable information in the logs.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsDevRevGrow = map[string]string{
@@ -953,6 +963,8 @@ var docsFirebaseAdmin = map[string]string{
 	"name":            "A custom name for your connector.",
 	"description":     "A description of what your connector is used for.",
 	"service_account": "The Firebase service account JSON.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsForter = map[string]string{
@@ -1012,6 +1024,8 @@ var docsGoogleCloudLogging = map[string]string{
 	"audit_filters": "Specify which events will be sent to the external audit service (including " +
 		"tenant selection).",
 	"troubleshoot_log_enabled": "Whether to send troubleshooting events.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsGoogleCloudTranslation = map[string]string{
@@ -1019,6 +1033,8 @@ var docsGoogleCloudTranslation = map[string]string{
 	"description":          "A description of what your connector is used for.",
 	"project_id":           "The Google Cloud project ID where the Google Cloud Translation is managed.",
 	"service_account_json": "Service Account JSON associated with the current project.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsGoogleMapsPlaces = map[string]string{
@@ -1064,6 +1080,8 @@ var docsHCaptcha = map[string]string{
 var docsHIBP = map[string]string{
 	"name":        "A custom name for your connector.",
 	"description": "A description of what your connector is used for.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsHTTP = map[string]string{
@@ -1102,7 +1120,8 @@ var docsHTTP = map[string]string{
 		"The context will have a \"body\" attribute, a \"headers\" attribute, and a " +
 		"\"statusCode\" attribute. See more details in the help guide",
 	"use_static_ips": "Whether the connector should send all requests from specific static IPs.",
-	"engine_id":      "",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsHubSpot = map[string]string{
@@ -1233,6 +1252,8 @@ var docsPingDirectory = map[string]string{
 	"description": "A description of what your connector is used for.",
 	"host":        "PingDirectory's REST API host.",
 	"port":        "PingDirectory's REST API port.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsPostmark = map[string]string{
@@ -1286,6 +1307,8 @@ var docsRecaptchaEnterprise = map[string]string{
 	"assessment_score": "When configured, the Recaptcha action will return the score without assessing " +
 		"the request. The score ranges between 0 and 1, where 1 is a human interaction " +
 		"and 0 is a bot.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsRecaptchaV2 = map[string]string{
@@ -1307,6 +1330,8 @@ var docsRekognition = map[string]string{
 	"secret_access_key": "The AWS secret access key",
 	"collection_id": "The collection to store registered users in. Should match `[a-zA-Z0-9_.-]+` " +
 		"pattern. Changing this will cause losing existing users.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsRNDReassigned = map[string]string{
@@ -1325,6 +1350,8 @@ var docsSalesforce = map[string]string{
 	"client_id":     "The consumer key of the connected app.",
 	"client_secret": "The consumer secret of the connected app.",
 	"version":       "REST API Version.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsSalesforceMarketingCloud = map[string]string{
@@ -1335,6 +1362,8 @@ var docsSalesforceMarketingCloud = map[string]string{
 	"client_secret": "Client secret issued when you create the API integration in Installed Packages.",
 	"scope":         "Space-separated list of data-access permissions for your connector.",
 	"account_id":    "Account identifier, or MID, of the target business unit.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsSardine = map[string]string{
@@ -1432,7 +1461,7 @@ var docsHTTPAuthOAuth2ClientCredentialsField = map[string]string{
 	"client_secret": "The OAuth 2.0 client secret used to authenticate against the token endpoint.",
 	"auth_url":      "The token endpoint URL used to request an access token.",
 	"auth_style": "How the client credentials are sent to the token endpoint. Either `header` to send them in the " +
-		"`Authorization` header, or `params` to send them in the request body.",
+		"`Authorization` header, or `body` to send them in the request body.",
 	"scopes":                "A space-separated list of OAuth scopes to request when fetching the access token.",
 	"token_request_headers": "Additional headers to include in the token request sent to the token endpoint.",
 }
@@ -1441,6 +1470,8 @@ var docsSlack = map[string]string{
 	"name":        "A custom name for your connector.",
 	"description": "A description of what your connector is used for.",
 	"token":       "The OAuth token for Slack's Bot User, used to authenticate API requests.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsSmartling = map[string]string{
@@ -1486,13 +1517,18 @@ var docsSnowflake = map[string]string{
 		"empty) to write events according to the default Descope cycle.",
 	"troubleshoot_log_enabled": "Whether to send troubleshooting events.",
 	"mask_pii":                 "Whether to mask personally identifiable information in the logs.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsSNS = map[string]string{
 	"name":          "A custom name for your connector.",
 	"description":   "A description of what your connector is used for.",
+	"auth_type":     "The authentication type to use.",
 	"access_key_id": "AWS Access key ID.",
 	"secret":        "AWS Secret Access Key.",
+	"role_arn":      "The Amazon Resource Name (ARN) of the role to assume.",
+	"external_id":   "The external ID to use when assuming the role.",
 	"region":        "AWS region to send requests to (e.g. `us-west-2`).",
 	"endpoint":      "An optional endpoint URL (hostname only or fully qualified URI).",
 	"origination_number": "An optional phone number from which the text messages are going to be sent. Make sure it " +
@@ -1515,6 +1551,8 @@ var docsSplunk = map[string]string{
 	"audit_filters": "Specify which events will be sent to the external audit service (including " +
 		"tenant selection).",
 	"troubleshoot_log_enabled": "Whether to send troubleshooting events.",
+	"engine_id": "The ID of the Descope Engine that runs this connector's actions inside your " +
+		"private network. Leave empty to run the connector in the Descope backend.",
 }
 
 var docsSQL = map[string]string{
@@ -1725,7 +1763,8 @@ var docsSettings = map[string]string{
 		"Tenant A and Tenant B will be treated as separate identities with isolated credentials, " +
 		"sessions, and MFA state.",
 	"allow_auth_hosting_iframe_embedding": "When enabled, Descope-hosted flows can be displayed within an iframe on " +
-		"your website. This modifies the security headers that typically prevent the page from being embedded.",
+		"your website. This modifies the security headers that typically prevent the page from " +
+		"being embedded.",
 	"refresh_token_rotation": "Every time the user refreshes their session token via their refresh token, the " +
 		"refresh token itself is also updated to a new one.",
 	"refresh_token_expiration": "The expiry time for the refresh token, after which the user must log in again. Use values " +

--- a/internal/models/project/connectors/auditwebhook.go
+++ b/internal/models/project/connectors/auditwebhook.go
@@ -23,6 +23,7 @@ var AuditWebhookAttributes = map[string]schema.Attribute{
 	"hmac_secret":    stringattr.SecretOptional(),
 	"insecure":       boolattr.Default(false),
 	"audit_filters":  listattr.Default[AuditFilterFieldModel](AuditFilterFieldAttributes),
+	"engine_id":      stringattr.Default(""),
 }
 
 // Model
@@ -38,17 +39,20 @@ type AuditWebhookModel struct {
 	HMACSecret     stringattr.Type                      `tfsdk:"hmac_secret"`
 	Insecure       boolattr.Type                        `tfsdk:"insecure"`
 	AuditFilters   listattr.Type[AuditFilterFieldModel] `tfsdk:"audit_filters"`
+	EngineID       stringattr.Type                      `tfsdk:"engine_id"`
 }
 
 func (m *AuditWebhookModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "audit-webhook"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *AuditWebhookModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/awss3.go
+++ b/internal/models/project/connectors/awss3.go
@@ -30,6 +30,7 @@ var AWSS3Attributes = map[string]schema.Attribute{
 	"audit_filters":            listattr.Default[AuditFilterFieldModel](AuditFilterFieldAttributes),
 	"troubleshoot_log_enabled": boolattr.Default(false),
 	"mask_pii":                 boolattr.Default(false),
+	"engine_id":                stringattr.Default(""),
 }
 
 // Model
@@ -50,17 +51,20 @@ type AWSS3Model struct {
 	AuditFilters           listattr.Type[AuditFilterFieldModel] `tfsdk:"audit_filters"`
 	TroubleshootLogEnabled boolattr.Type                        `tfsdk:"troubleshoot_log_enabled"`
 	MaskPII                boolattr.Type                        `tfsdk:"mask_pii"`
+	EngineID               stringattr.Type                      `tfsdk:"engine_id"`
 }
 
 func (m *AWSS3Model) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "aws-s3"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *AWSS3Model) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/awssesemailvalidation.go
+++ b/internal/models/project/connectors/awssesemailvalidation.go
@@ -24,6 +24,7 @@ var AWSSESEmailValidationAttributes = map[string]schema.Attribute{
 	"role_arn":          stringattr.Default(""),
 	"external_id":       stringattr.Default(""),
 	"region":            stringattr.Required(),
+	"engine_id":         stringattr.Default(""),
 }
 
 // Model
@@ -40,17 +41,20 @@ type AWSSESEmailValidationModel struct {
 	RoleARN         stringattr.Type `tfsdk:"role_arn"`
 	ExternalID      stringattr.Type `tfsdk:"external_id"`
 	Region          stringattr.Type `tfsdk:"region"`
+	EngineID        stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *AWSSESEmailValidationModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "aws-ses-email-validation"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *AWSSESEmailValidationModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/awstranslate.go
+++ b/internal/models/project/connectors/awstranslate.go
@@ -17,6 +17,7 @@ var AWSTranslateAttributes = map[string]schema.Attribute{
 	"secret_access_key": stringattr.SecretRequired(),
 	"session_token":     stringattr.SecretOptional(),
 	"region":            stringattr.Required(),
+	"engine_id":         stringattr.Default(""),
 }
 
 // Model
@@ -30,17 +31,20 @@ type AWSTranslateModel struct {
 	SecretAccessKey stringattr.Type `tfsdk:"secret_access_key"`
 	SessionToken    stringattr.Type `tfsdk:"session_token"`
 	Region          stringattr.Type `tfsdk:"region"`
+	EngineID        stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *AWSTranslateModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "aws-translate"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *AWSTranslateModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/datadog.go
+++ b/internal/models/project/connectors/datadog.go
@@ -26,6 +26,7 @@ var DatadogAttributes = map[string]schema.Attribute{
 	"audit_filters":            listattr.Default[AuditFilterFieldModel](AuditFilterFieldAttributes),
 	"troubleshoot_log_enabled": boolattr.Default(false),
 	"mask_pii":                 boolattr.Default(false),
+	"engine_id":                stringattr.Default(""),
 }
 
 // Model
@@ -43,17 +44,20 @@ type DatadogModel struct {
 	AuditFilters           listattr.Type[AuditFilterFieldModel] `tfsdk:"audit_filters"`
 	TroubleshootLogEnabled boolattr.Type                        `tfsdk:"troubleshoot_log_enabled"`
 	MaskPII                boolattr.Type                        `tfsdk:"mask_pii"`
+	EngineID               stringattr.Type                      `tfsdk:"engine_id"`
 }
 
 func (m *DatadogModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "datadog"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *DatadogModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/engine_internal_test.go
+++ b/internal/models/project/connectors/engine_internal_test.go
@@ -1,9 +1,12 @@
 package connectors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
+	"github.com/descope/terraform-provider-descope/internal/models/helpers"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,4 +41,27 @@ func TestConnectorEngine(t *testing.T) {
 	var missingEngineID stringattr.Type
 	getConnectorEngine(map[string]any{}, &missingEngineID)
 	assert.Equal(t, "", missingEngineID.ValueString())
+}
+
+// TestHIBPConnectorEngine verifies that the generated HIBP model wires the engine_id
+// attribute through the top-level executor fields, like the HTTP connector does.
+func TestHIBPConnectorEngine(t *testing.T) {
+	diags := diag.Diagnostics{}
+	h := helpers.NewHandler(context.Background(), &diags)
+	h.Refs.Add(helpers.ConnectorReferenceKey, "hibp", "CIHIBPExample", "My HIBP Connector")
+
+	m := &HIBPModel{
+		ID:       stringattr.Value("CIHIBPExample"),
+		Name:     stringattr.Value("My HIBP Connector"),
+		EngineID: stringattr.Value("CIEngineExample"),
+	}
+	data := m.Values(h)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "engine", data["executorType"])
+	assert.Equal(t, "CIEngineExample", data["executorId"])
+
+	var round HIBPModel
+	round.SetValues(h, data)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "CIEngineExample", round.EngineID.ValueString())
 }

--- a/internal/models/project/connectors/firebaseadmin.go
+++ b/internal/models/project/connectors/firebaseadmin.go
@@ -14,6 +14,7 @@ var FirebaseAdminAttributes = map[string]schema.Attribute{
 	"description": stringattr.Default(""),
 
 	"service_account": stringattr.SecretRequired(),
+	"engine_id":       stringattr.Default(""),
 }
 
 // Model
@@ -24,17 +25,20 @@ type FirebaseAdminModel struct {
 	Description stringattr.Type `tfsdk:"description"`
 
 	ServiceAccount stringattr.Type `tfsdk:"service_account"`
+	EngineID       stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *FirebaseAdminModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "firebase-admin"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *FirebaseAdminModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/googlecloudlogging.go
+++ b/internal/models/project/connectors/googlecloudlogging.go
@@ -22,6 +22,7 @@ var GoogleCloudLoggingAttributes = map[string]schema.Attribute{
 	"audit_enabled":            boolattr.Default(true),
 	"audit_filters":            listattr.Default[AuditFilterFieldModel](AuditFilterFieldAttributes),
 	"troubleshoot_log_enabled": boolattr.Default(false),
+	"engine_id":                stringattr.Default(""),
 }
 
 // Model
@@ -35,17 +36,20 @@ type GoogleCloudLoggingModel struct {
 	AuditEnabled           boolattr.Type                        `tfsdk:"audit_enabled"`
 	AuditFilters           listattr.Type[AuditFilterFieldModel] `tfsdk:"audit_filters"`
 	TroubleshootLogEnabled boolattr.Type                        `tfsdk:"troubleshoot_log_enabled"`
+	EngineID               stringattr.Type                      `tfsdk:"engine_id"`
 }
 
 func (m *GoogleCloudLoggingModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "googlecloudlogging"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *GoogleCloudLoggingModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/googlecloudtranslation.go
+++ b/internal/models/project/connectors/googlecloudtranslation.go
@@ -15,6 +15,7 @@ var GoogleCloudTranslationAttributes = map[string]schema.Attribute{
 
 	"project_id":           stringattr.Required(),
 	"service_account_json": stringattr.SecretRequired(),
+	"engine_id":            stringattr.Default(""),
 }
 
 // Model
@@ -26,17 +27,20 @@ type GoogleCloudTranslationModel struct {
 
 	ProjectID          stringattr.Type `tfsdk:"project_id"`
 	ServiceAccountJSON stringattr.Type `tfsdk:"service_account_json"`
+	EngineID           stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *GoogleCloudTranslationModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "google-cloud-translation"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *GoogleCloudTranslationModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/hibp.go
+++ b/internal/models/project/connectors/hibp.go
@@ -12,6 +12,8 @@ var HIBPAttributes = map[string]schema.Attribute{
 	"id":          stringattr.IdentifierMatched(),
 	"name":        stringattr.Required(stringattr.StandardLenValidator),
 	"description": stringattr.Default(""),
+
+	"engine_id": stringattr.Default(""),
 }
 
 // Model
@@ -20,17 +22,21 @@ type HIBPModel struct {
 	ID          stringattr.Type `tfsdk:"id"`
 	Name        stringattr.Type `tfsdk:"name"`
 	Description stringattr.Type `tfsdk:"description"`
+
+	EngineID stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *HIBPModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "hibp"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *HIBPModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 }
 
 // Configuration

--- a/internal/models/project/connectors/pingdirectory.go
+++ b/internal/models/project/connectors/pingdirectory.go
@@ -14,8 +14,9 @@ var PingDirectoryAttributes = map[string]schema.Attribute{
 	"name":        stringattr.Required(stringattr.StandardLenValidator),
 	"description": stringattr.Default(""),
 
-	"host": stringattr.Required(),
-	"port": floatattr.Required(),
+	"host":      stringattr.Required(),
+	"port":      floatattr.Required(),
+	"engine_id": stringattr.Default(""),
 }
 
 // Model
@@ -25,19 +26,22 @@ type PingDirectoryModel struct {
 	Name        stringattr.Type `tfsdk:"name"`
 	Description stringattr.Type `tfsdk:"description"`
 
-	Host stringattr.Type `tfsdk:"host"`
-	Port floatattr.Type  `tfsdk:"port"`
+	Host     stringattr.Type `tfsdk:"host"`
+	Port     floatattr.Type  `tfsdk:"port"`
+	EngineID stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *PingDirectoryModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "ping-directory"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *PingDirectoryModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/recaptchaenterprise.go
+++ b/internal/models/project/connectors/recaptchaenterprise.go
@@ -27,6 +27,7 @@ var RecaptchaEnterpriseAttributes = map[string]schema.Attribute{
 	"override_assessment": boolattr.Default(false),
 	"bot_threshold":       floatattr.Default(0.5),
 	"assessment_score":    floatattr.Default(0.5),
+	"engine_id":           stringattr.Default(""),
 }
 
 // Model
@@ -44,17 +45,20 @@ type RecaptchaEnterpriseModel struct {
 	OverrideAssessment boolattr.Type   `tfsdk:"override_assessment"`
 	BotThreshold       floatattr.Type  `tfsdk:"bot_threshold"`
 	AssessmentScore    floatattr.Type  `tfsdk:"assessment_score"`
+	EngineID           stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *RecaptchaEnterpriseModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "recaptcha-enterprise"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *RecaptchaEnterpriseModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/rekognition.go
+++ b/internal/models/project/connectors/rekognition.go
@@ -16,6 +16,7 @@ var RekognitionAttributes = map[string]schema.Attribute{
 	"access_key_id":     stringattr.Required(),
 	"secret_access_key": stringattr.SecretRequired(),
 	"collection_id":     stringattr.Required(),
+	"engine_id":         stringattr.Default(""),
 }
 
 // Model
@@ -28,17 +29,20 @@ type RekognitionModel struct {
 	AccessKeyID     stringattr.Type `tfsdk:"access_key_id"`
 	SecretAccessKey stringattr.Type `tfsdk:"secret_access_key"`
 	CollectionID    stringattr.Type `tfsdk:"collection_id"`
+	EngineID        stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *RekognitionModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "rekognition"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *RekognitionModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/salesforce.go
+++ b/internal/models/project/connectors/salesforce.go
@@ -17,6 +17,7 @@ var SalesforceAttributes = map[string]schema.Attribute{
 	"client_id":     stringattr.Required(),
 	"client_secret": stringattr.SecretRequired(),
 	"version":       stringattr.Required(),
+	"engine_id":     stringattr.Default(""),
 }
 
 // Model
@@ -30,17 +31,20 @@ type SalesforceModel struct {
 	ClientID     stringattr.Type `tfsdk:"client_id"`
 	ClientSecret stringattr.Type `tfsdk:"client_secret"`
 	Version      stringattr.Type `tfsdk:"version"`
+	EngineID     stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *SalesforceModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "salesforce"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *SalesforceModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/salesforcemarketingcloud.go
+++ b/internal/models/project/connectors/salesforcemarketingcloud.go
@@ -18,6 +18,7 @@ var SalesforceMarketingCloudAttributes = map[string]schema.Attribute{
 	"client_secret": stringattr.SecretRequired(),
 	"scope":         stringattr.Default(""),
 	"account_id":    stringattr.Default(""),
+	"engine_id":     stringattr.Default(""),
 }
 
 // Model
@@ -32,17 +33,20 @@ type SalesforceMarketingCloudModel struct {
 	ClientSecret stringattr.Type `tfsdk:"client_secret"`
 	Scope        stringattr.Type `tfsdk:"scope"`
 	AccountID    stringattr.Type `tfsdk:"account_id"`
+	EngineID     stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *SalesforceMarketingCloudModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "salesforce-marketing-cloud"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *SalesforceMarketingCloudModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/slack.go
+++ b/internal/models/project/connectors/slack.go
@@ -13,7 +13,8 @@ var SlackAttributes = map[string]schema.Attribute{
 	"name":        stringattr.Required(stringattr.StandardLenValidator),
 	"description": stringattr.Default(""),
 
-	"token": stringattr.SecretRequired(),
+	"token":     stringattr.SecretRequired(),
+	"engine_id": stringattr.Default(""),
 }
 
 // Model
@@ -23,18 +24,21 @@ type SlackModel struct {
 	Name        stringattr.Type `tfsdk:"name"`
 	Description stringattr.Type `tfsdk:"description"`
 
-	Token stringattr.Type `tfsdk:"token"`
+	Token    stringattr.Type `tfsdk:"token"`
+	EngineID stringattr.Type `tfsdk:"engine_id"`
 }
 
 func (m *SlackModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "slack"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *SlackModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/snowflake.go
+++ b/internal/models/project/connectors/snowflake.go
@@ -30,6 +30,7 @@ var SnowflakeAttributes = map[string]schema.Attribute{
 	"min_flush_interval_minutes": floatattr.Default(15),
 	"troubleshoot_log_enabled":   boolattr.Default(false),
 	"mask_pii":                   boolattr.Default(false),
+	"engine_id":                  stringattr.Default(""),
 }
 
 // Model
@@ -50,17 +51,20 @@ type SnowflakeModel struct {
 	MinFlushIntervalMinutes floatattr.Type                       `tfsdk:"min_flush_interval_minutes"`
 	TroubleshootLogEnabled  boolattr.Type                        `tfsdk:"troubleshoot_log_enabled"`
 	MaskPII                 boolattr.Type                        `tfsdk:"mask_pii"`
+	EngineID                stringattr.Type                      `tfsdk:"engine_id"`
 }
 
 func (m *SnowflakeModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "snowflake"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *SnowflakeModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/internal/models/project/connectors/splunk.go
+++ b/internal/models/project/connectors/splunk.go
@@ -24,6 +24,7 @@ var SplunkAttributes = map[string]schema.Attribute{
 	"audit_enabled":            boolattr.Default(true),
 	"audit_filters":            listattr.Default[AuditFilterFieldModel](AuditFilterFieldAttributes),
 	"troubleshoot_log_enabled": boolattr.Default(false),
+	"engine_id":                stringattr.Default(""),
 }
 
 // Model
@@ -39,17 +40,20 @@ type SplunkModel struct {
 	AuditEnabled           boolattr.Type                        `tfsdk:"audit_enabled"`
 	AuditFilters           listattr.Type[AuditFilterFieldModel] `tfsdk:"audit_filters"`
 	TroubleshootLogEnabled boolattr.Type                        `tfsdk:"troubleshoot_log_enabled"`
+	EngineID               stringattr.Type                      `tfsdk:"engine_id"`
 }
 
 func (m *SplunkModel) Values(h *helpers.Handler) map[string]any {
 	data := connectorValues(m.ID, m.Name, m.Description, h)
 	data["type"] = "splunk"
 	data["configuration"] = m.ConfigurationValues(h)
+	setConnectorEngine(data, m.EngineID)
 	return data
 }
 
 func (m *SplunkModel) SetValues(h *helpers.Handler, data map[string]any) {
 	setConnectorValues(&m.ID, &m.Name, &m.Description, data, h)
+	getConnectorEngine(data, &m.EngineID)
 	if c, ok := data["configuration"].(map[string]any); ok {
 		m.SetConfigurationValues(c, h)
 	}

--- a/tools/terragen/conngen/connector.go
+++ b/tools/terragen/conngen/connector.go
@@ -42,10 +42,30 @@ func (c *Connector) SupportsStaticIPs() bool {
 }
 
 // SupportsEngine reports whether the connector can be assigned to a Descope engine via the
-// engine_id attribute. Engine execution is currently limited to the general purpose HTTP
-// connector, so the gate is keyed on the connector id rather than external template metadata.
+// engine_id attribute. Engine execution is currently limited to the connectors that the
+// engine runtime ships with, so the gate is keyed on the connector id rather than external
+// template metadata.
 func (c *Connector) SupportsEngine() bool {
-	return c.ID == "http"
+	return slices.Contains([]string{
+		"audit-webhook",
+		"aws-s3",
+		"aws-ses-email-validation",
+		"aws-translate",
+		"datadog",
+		"firebase-admin",
+		"google-cloud-translation",
+		"googlecloudlogging",
+		"hibp",
+		"http",
+		"ping-directory",
+		"recaptcha-enterprise",
+		"rekognition",
+		"salesforce",
+		"salesforce-marketing-cloud",
+		"slack",
+		"snowflake",
+		"splunk",
+	}, c.ID)
 }
 
 func (c *Connector) StructName() string {

--- a/tools/terragen/conngen/parse.go
+++ b/tools/terragen/conngen/parse.go
@@ -43,6 +43,10 @@ func MergeDocs(conns *Connectors, sc *schema.Schema) {
 func mergeConnectorDocs(c *Connector, sc *schema.Schema) {
 	model := findConnectorModel(sc, c.StructName())
 	for _, field := range model.Fields {
+		if field.Name == "engine_id" && c.SupportsEngine() {
+			field.Description = wordwrap.WrapString(utils.DefaultConnectorEngineIDText, 80)
+			continue
+		}
 		for _, f := range c.Fields {
 			if field.Name == f.AttributeName() {
 				if f.Description != "" {

--- a/tools/terragen/utils/templates.go
+++ b/tools/terragen/utils/templates.go
@@ -16,6 +16,7 @@ const PlaceholderDescription = `// description for`
 // defaults for common connector fields
 const DefaultConnectorNameText = "A custom name for your connector."
 const DefaultConnectorDescriptionText = "A description of what your connector is used for."
+const DefaultConnectorEngineIDText = "The ID of the Descope Engine that runs this connector's actions inside your private network. Leave empty to run the connector in the Descope backend."
 
 // markdown descriptions with paragraphs will require a custom template to look good
 const preserveParagraphs = false


### PR DESCRIPTION
## Summary

- Allow binding a Descope Engine via the `engine_id` attribute on all connectors that the engine runtime ships with, matching the existing HTTP connector support: `audit-webhook`, `aws-s3`, `aws-ses-email-validation`, `aws-translate`, `datadog`, `firebase-admin`, `google-cloud-translation`, `googlecloudlogging`, `hibp`, `ping-directory`, `recaptcha-enterprise`, `rekognition`, `salesforce`, `salesforce-marketing-cloud`, `slack`, `snowflake` and `splunk`.
- The gate lives in terragen's `SupportsEngine()` allowlist; all connector models were regenerated with the `engine_id` attribute and the `setConnectorEngine`/`getConnectorEngine` wiring.
- The `engine_id` attribute now carries a proper description in the generated documentation (it was previously empty for the HTTP connector).
- Added the missing `allow_auth_hosting_iframe_embedding` section to the raw settings docs so regeneration no longer drops its description from the generated docs.

## Context

Requested by a customer that runs connectors on a self-hosted Descope Engine in a FedRAMP environment and manages their project through the Terraform provider. The backend already accepts the top-level `executorType`/`executorId` fields on any connector, so no server-side change is needed.

## Testing

- Added a unit test that verifies the generated HIBP model round-trips `engine_id` through the top-level executor fields.
- `go build`, `go test ./...`, `go vet` and `gofmt` are all clean.
- Acceptance tests for engine binding remain skipped since engineservice is not deployed in the acceptance-test environment.