### PR TITLE
feat(applications): support backchannel logout URL on OIDC applications

### DIFF
--- a/docs/raw/project/applications/oidc.md
+++ b/docs/raw/project/applications/oidc.md
@@ -78,6 +78,27 @@ the user to authenticate via the Descope flow, regardless of the SP's request.
 
 
 
+backchannel_logout_url
+----------------------
+
+- Type: `string`
+
+The URL that Descope notifies with a logout token when the user's session ends,
+as per the [OIDC Back-Channel Logout](https://openid.net/specs/openid-connect-backchannel-1_0.html)
+specification. Leave empty to disable back-channel logout notifications for this application.
+
+
+
+custom_idp_initiated_login_page_url
+-----------------------------------
+
+- Type: `string`
+
+A custom login page URL to redirect users to on IdP-initiated login flows,
+instead of the default login page.
+
+
+
 client_id
 ---------
 
@@ -179,7 +200,18 @@ default_audience
 
 - Type: `string`
 
-Controls the default `aud` claim of tokens issued for this application. One of `"projectId"` (the project ID only), `"clientId"` (the dedicated client ID only), or `""` (default — both). Only applies to modern apps that set a `client_type`; legacy apps always use the project ID, so the empty default leaves their behavior unchanged.
+Controls the default `aud` claim of tokens issued for this application. One of `"projectId"` (the project ID only), `"clientId"` (the dedicated client ID only), `"appId"` (the application ID only), `"empty"` (no `aud` claim at all), or `""` (default — both the project ID and the client ID). Only applies to modern apps that set a `client_type`; legacy apps always use the project ID, so the empty default leaves their behavior unchanged.
+
+
+
+trusted_apps_audience
+---------------------
+
+- Type: `string`
+
+Controls the audience values appended to the issued token's `aud` claim for trusted sibling
+applications. One of `"projectId"`, `"clientId"`, `"appId"`, `"empty"` (add none), or `""`
+(default — both the project ID and the client ID). Independent of `default_audience`.
 
 
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -355,12 +355,14 @@ Optional:
 
 - `approved_redirect_urls` (Set of String) A list of approved redirect URLs for this application (supports `*` wildcards). When set, redirect URIs are validated against this per-app list; when empty, validation falls back to the project's approved/trusted domains.
 - `authorization_code_disabled` (Boolean) Disables the `authorization_code` grant type for this application.
+- `backchannel_logout_url` (String) The URL that Descope notifies with a logout token when the user's session ends, as per the [OIDC Back-Channel Logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) specification. Leave empty to disable back-channel logout notifications for this application.
 - `claims` (List of String) A list of supported claims. e.g. `sub`, `email`, `exp`.
 - `client_credentials_disabled` (Boolean) Disables the `client_credentials` grant type for this application.
 - `client_id` (String) A dedicated OIDC `client_id` to import for this application. When omitted, the `client_id` is computed by the server; when set, it must be unique within the project. Can only be set when the application is created, and attempting to change it on an existing application will fail.
 - `client_secret` (String, Sensitive) A dedicated OIDC `client_secret` to import for this application, applied on creation only. When omitted, a secret is generated server-side. The value is sensitive and is not returned on subsequent reads.
 - `client_type` (String) OAuth client confidentiality. One of `""` (default — legacy access-key authentication), `"confidential"` (a dedicated client secret is generated for the app), or `"public"`.
-- `default_audience` (String) Controls the default `aud` claim of tokens issued for this application. One of `"projectId"` (the project ID only), `"clientId"` (the dedicated client ID only), or `""` (default — both). Only applies to modern apps that set a `client_type`; legacy apps always use the project ID, so the empty default leaves their behavior unchanged.
+- `custom_idp_initiated_login_page_url` (String) A custom login page URL to redirect users to on IdP-initiated login flows, instead of the default login page.
+- `default_audience` (String) Controls the default `aud` claim of tokens issued for this application. One of `"projectId"` (the project ID only), `"clientId"` (the dedicated client ID only), `"appId"` (the application ID only), `"empty"` (no `aud` claim at all), or `""` (default — both the project ID and the client ID). Only applies to modern apps that set a `client_type`; legacy apps always use the project ID, so the empty default leaves their behavior unchanged.
 - `description` (String) A description for the OIDC application.
 - `device_code_disabled` (Boolean) Disables the `urn:ietf:params:oauth:grant-type:device_code` grant type for this application.
 - `disabled` (Boolean) Whether the application should be enabled or disabled.
@@ -373,6 +375,7 @@ Optional:
 - `permissions` (Attributes List) (see [below for nested schema](#nestedatt--applications--oidc_applications--permissions))
 - `refresh_token_disabled` (Boolean) Disables the `refresh_token` grant type for this application.
 - `roles` (Attributes List) (see [below for nested schema](#nestedatt--applications--oidc_applications--roles))
+- `trusted_apps_audience` (String) Controls the audience values appended to the issued token's `aud` claim for trusted sibling applications. One of `"projectId"`, `"clientId"`, `"appId"`, `"empty"` (add none), or `""` (default — both the project ID and the client ID). Independent of `default_audience`.
 
 <a id="nestedatt--applications--oidc_applications--permissions"></a>
 ### Nested Schema for `applications.oidc_applications.permissions`

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -207,6 +207,11 @@ var docsOIDC = map[string]string{
 	"claims": "A list of supported claims. e.g. `sub`, `email`, `exp`.",
 	"force_authentication": "This configuration overrides the default behavior of the SSO application and forces " +
 		"the user to authenticate via the Descope flow, regardless of the SP's request.",
+	"backchannel_logout_url": "The URL that Descope notifies with a logout token when the user's session ends, " +
+		"as per the [OIDC Back-Channel Logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) " +
+		"specification. Leave empty to disable back-channel logout notifications for this application.",
+	"custom_idp_initiated_login_page_url": "A custom login page URL to redirect users to on IdP-initiated login flows, " +
+		"instead of the default login page.",
 	"client_id": "A dedicated OIDC `client_id` to import for this application. When omitted, the `client_id` is computed " +
 		"by the server; when set, it must be unique within the project. Can only be set when the application is " +
 		"created, and attempting to change it on an existing application will fail.",
@@ -223,9 +228,12 @@ var docsOIDC = map[string]string{
 	"jwt_bearer_disabled":         "Disables the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type for this application.",
 	"device_code_disabled":        "Disables the `urn:ietf:params:oauth:grant-type:device_code` grant type for this application.",
 	"force_pkce":                  "When enabled, the authorization code flow requires PKCE in addition to the normal client authentication. A confidential client must then present both its client secret and a valid PKCE `code_verifier`. Public clients always use PKCE regardless of this setting.",
-	"default_audience":            "Controls the default `aud` claim of tokens issued for this application. One of `\"projectId\"` (the project ID only), `\"clientId\"` (the dedicated client ID only), or `\"\"` (default — both). Only applies to modern apps that set a `client_type`; legacy apps always use the project ID, so the empty default leaves their behavior unchanged.",
-	"permissions":                 "",
-	"roles":                       "",
+	"default_audience":            "Controls the default `aud` claim of tokens issued for this application. One of `\"projectId\"` (the project ID only), `\"clientId\"` (the dedicated client ID only), `\"appId\"` (the application ID only), `\"empty\"` (no `aud` claim at all), or `\"\"` (default — both the project ID and the client ID). Only applies to modern apps that set a `client_type`; legacy apps always use the project ID, so the empty default leaves their behavior unchanged.",
+	"trusted_apps_audience": "Controls the audience values appended to the issued token's `aud` claim for trusted sibling " +
+		"applications. One of `\"projectId\"`, `\"clientId\"`, `\"appId\"`, `\"empty\"` (add none), or `\"\"` " +
+		"(default — both the project ID and the client ID). Independent of `default_audience`.",
+	"permissions": "",
+	"roles":       "",
 }
 
 var docsSAML = map[string]string{

--- a/internal/models/project/applications/applications_test.go
+++ b/internal/models/project/applications/applications_test.go
@@ -159,7 +159,7 @@ func TestApplications(t *testing.T) {
 							jwt_bearer_disabled = true
 							device_code_disabled = true
 							force_pkce = true
-							default_audience = "clientId"
+							default_audience = "appId"
 							trusted_apps_audience = "empty"
 						}
 					]
@@ -174,6 +174,7 @@ func TestApplications(t *testing.T) {
 					"backchannel_logout_url":              "https://example.com/backchannel-logout2",
 					"custom_idp_initiated_login_page_url": "https://example.com/idp-login2",
 					"client_id":                           "my-custom-oidc-client",
+					"default_audience":                    "appId",
 					"trusted_apps_audience":               "empty",
 				},
 			}),

--- a/internal/models/project/applications/applications_test.go
+++ b/internal/models/project/applications/applications_test.go
@@ -52,6 +52,8 @@ func TestApplications(t *testing.T) {
 							login_page_url = "https://example.com/login"
 							claims = ["email", "name"]
 							force_authentication = true
+							backchannel_logout_url = "https://example.com/backchannel-logout"
+							custom_idp_initiated_login_page_url = "https://example.com/idp-login"
 
 							client_id = "my-custom-oidc-client"
 							client_secret = "my-custom-oidc-secret-0123456789"
@@ -64,6 +66,7 @@ func TestApplications(t *testing.T) {
 							device_code_disabled = true
 							force_pkce = true
 							default_audience = "clientId"
+							trusted_apps_audience = "appId"
 						}
 					]
 				}
@@ -71,17 +74,19 @@ func TestApplications(t *testing.T) {
 			Check: p.Check(map[string]any{
 				"applications.oidc_applications.#": 1,
 				"applications.oidc_applications.0": map[string]any{
-					"id":                   testacc.AttributeHasPrefix("SA"),
-					"name":                 "foo",
-					"description":          "bar",
-					"logo":                 "https://example.com/logo.png",
-					"disabled":             true,
-					"login_page_url":       "https://example.com/login",
-					"claims":               []string{"email", "name"},
-					"force_authentication": true,
-					"client_id":            "my-custom-oidc-client",
-					"client_secret":        testacc.AttributeIsSet,
-					"client_type":          "confidential",
+					"id":                                  testacc.AttributeHasPrefix("SA"),
+					"name":                                "foo",
+					"description":                         "bar",
+					"logo":                                "https://example.com/logo.png",
+					"disabled":                            true,
+					"login_page_url":                      "https://example.com/login",
+					"claims":                              []string{"email", "name"},
+					"force_authentication":                true,
+					"backchannel_logout_url":              "https://example.com/backchannel-logout",
+					"custom_idp_initiated_login_page_url": "https://example.com/idp-login",
+					"client_id":                           "my-custom-oidc-client",
+					"client_secret":                       testacc.AttributeIsSet,
+					"client_type":                         "confidential",
 					"approved_redirect_urls": []string{
 						"https://example.com/cb",
 						"https://example.com/cb2",
@@ -93,6 +98,7 @@ func TestApplications(t *testing.T) {
 					"device_code_disabled":        true,
 					"force_pkce":                  true,
 					"default_audience":            "clientId",
+					"trusted_apps_audience":       "appId",
 				},
 			}),
 		},
@@ -140,6 +146,8 @@ func TestApplications(t *testing.T) {
 							login_page_url = "https://example.com/login"
 							claims = ["email", "name"]
 							force_authentication = true
+							backchannel_logout_url = "https://example.com/backchannel-logout2"
+							custom_idp_initiated_login_page_url = "https://example.com/idp-login2"
 
 							client_id = "my-custom-oidc-client"
 							client_secret = "my-custom-oidc-secret-0123456789"
@@ -152,6 +160,7 @@ func TestApplications(t *testing.T) {
 							device_code_disabled = true
 							force_pkce = true
 							default_audience = "clientId"
+							trusted_apps_audience = "empty"
 						}
 					]
 				}
@@ -159,10 +168,13 @@ func TestApplications(t *testing.T) {
 			Check: p.Check(map[string]any{
 				"applications.oidc_applications.#": 1,
 				"applications.oidc_applications.0": map[string]any{
-					"id":          testacc.AttributeHasPrefix("SA"),
-					"name":        "foo",
-					"description": "bar2",
-					"client_id":   "my-custom-oidc-client",
+					"id":                                  testacc.AttributeHasPrefix("SA"),
+					"name":                                "foo",
+					"description":                         "bar2",
+					"backchannel_logout_url":              "https://example.com/backchannel-logout2",
+					"custom_idp_initiated_login_page_url": "https://example.com/idp-login2",
+					"client_id":                           "my-custom-oidc-client",
+					"trusted_apps_audience":               "empty",
 				},
 			}),
 		},

--- a/internal/models/project/applications/oidc.go
+++ b/internal/models/project/applications/oidc.go
@@ -18,20 +18,23 @@ var OIDCAttributes = map[string]schema.Attribute{
 	"logo":        stringattr.Default(""),
 	"disabled":    boolattr.Default(false),
 
-	"login_page_url":              stringattr.Default(""),
-	"claims":                      strlistattr.Default(),
-	"force_authentication":        boolattr.Default(false),
-	"client_id":                   stringattr.Optional(),
-	"client_secret":               stringattr.SecretGenerated(true),
-	"client_type":                 stringattr.Default("", stringvalidator.OneOf("", "confidential", "public")),
-	"approved_redirect_urls":      strsetattr.Default(),
-	"authorization_code_disabled": boolattr.Default(false),
-	"client_credentials_disabled": boolattr.Default(false),
-	"refresh_token_disabled":      boolattr.Default(false),
-	"jwt_bearer_disabled":         boolattr.Default(false),
-	"device_code_disabled":        boolattr.Default(false),
-	"force_pkce":                  boolattr.Default(false),
-	"default_audience":            stringattr.Default("", stringvalidator.OneOf("", "projectId", "clientId")),
+	"login_page_url":                      stringattr.Default(""),
+	"claims":                              strlistattr.Default(),
+	"force_authentication":                boolattr.Default(false),
+	"backchannel_logout_url":              stringattr.Default(""),
+	"custom_idp_initiated_login_page_url": stringattr.Default(""),
+	"client_id":                           stringattr.Optional(),
+	"client_secret":                       stringattr.SecretGenerated(true),
+	"client_type":                         stringattr.Default("", stringvalidator.OneOf("", "confidential", "public")),
+	"approved_redirect_urls":              strsetattr.Default(),
+	"authorization_code_disabled":         boolattr.Default(false),
+	"client_credentials_disabled":         boolattr.Default(false),
+	"refresh_token_disabled":              boolattr.Default(false),
+	"jwt_bearer_disabled":                 boolattr.Default(false),
+	"device_code_disabled":                boolattr.Default(false),
+	"force_pkce":                          boolattr.Default(false),
+	"default_audience":                    stringattr.Default("", stringvalidator.OneOf("", "projectId", "clientId", "appId", "empty")),
+	"trusted_apps_audience":               stringattr.Default("", stringvalidator.OneOf("", "projectId", "clientId", "appId", "empty")),
 
 	"permissions": listattr.Default[SSOAppPermissionModel](SSOAppPermissionAttributes),
 	"roles":       listattr.Default[SSOAppRoleModel](SSOAppRoleAttributes),
@@ -46,20 +49,23 @@ type OIDCModel struct {
 	Logo        stringattr.Type `tfsdk:"logo"`
 	Disabled    boolattr.Type   `tfsdk:"disabled"`
 
-	LoginPageURL              stringattr.Type  `tfsdk:"login_page_url"`
-	Claims                    strlistattr.Type `tfsdk:"claims"`
-	ForceAuthentication       boolattr.Type    `tfsdk:"force_authentication"`
-	ClientID                  stringattr.Type  `tfsdk:"client_id"`
-	ClientSecret              stringattr.Type  `tfsdk:"client_secret"`
-	ClientType                stringattr.Type  `tfsdk:"client_type"`
-	ApprovedRedirectURLs      strsetattr.Type  `tfsdk:"approved_redirect_urls"`
-	AuthorizationCodeDisabled boolattr.Type    `tfsdk:"authorization_code_disabled"`
-	ClientCredentialsDisabled boolattr.Type    `tfsdk:"client_credentials_disabled"`
-	RefreshTokenDisabled      boolattr.Type    `tfsdk:"refresh_token_disabled"`
-	JWTBearerDisabled         boolattr.Type    `tfsdk:"jwt_bearer_disabled"`
-	DeviceCodeDisabled        boolattr.Type    `tfsdk:"device_code_disabled"`
-	ForcePkce                 boolattr.Type    `tfsdk:"force_pkce"`
-	DefaultAudience           stringattr.Type  `tfsdk:"default_audience"`
+	LoginPageURL                   stringattr.Type  `tfsdk:"login_page_url"`
+	Claims                         strlistattr.Type `tfsdk:"claims"`
+	ForceAuthentication            boolattr.Type    `tfsdk:"force_authentication"`
+	BackchannelLogoutURL           stringattr.Type  `tfsdk:"backchannel_logout_url"`
+	CustomIDPInitiatedLoginPageURL stringattr.Type  `tfsdk:"custom_idp_initiated_login_page_url"`
+	ClientID                       stringattr.Type  `tfsdk:"client_id"`
+	ClientSecret                   stringattr.Type  `tfsdk:"client_secret"`
+	ClientType                     stringattr.Type  `tfsdk:"client_type"`
+	ApprovedRedirectURLs           strsetattr.Type  `tfsdk:"approved_redirect_urls"`
+	AuthorizationCodeDisabled      boolattr.Type    `tfsdk:"authorization_code_disabled"`
+	ClientCredentialsDisabled      boolattr.Type    `tfsdk:"client_credentials_disabled"`
+	RefreshTokenDisabled           boolattr.Type    `tfsdk:"refresh_token_disabled"`
+	JWTBearerDisabled              boolattr.Type    `tfsdk:"jwt_bearer_disabled"`
+	DeviceCodeDisabled             boolattr.Type    `tfsdk:"device_code_disabled"`
+	ForcePkce                      boolattr.Type    `tfsdk:"force_pkce"`
+	DefaultAudience                stringattr.Type  `tfsdk:"default_audience"`
+	TrustedAppsAudience            stringattr.Type  `tfsdk:"trusted_apps_audience"`
 
 	Permissions listattr.Type[SSOAppPermissionModel] `tfsdk:"permissions"`
 	Roles       listattr.Type[SSOAppRoleModel]       `tfsdk:"roles"`
@@ -70,6 +76,8 @@ func (m *OIDCModel) Values(h *helpers.Handler) map[string]any {
 	stringattr.Get(m.LoginPageURL, settings, "loginPageUrl")
 	strlistattr.Get(m.Claims, settings, "claims", h)
 	boolattr.Get(m.ForceAuthentication, settings, "forceAuthentication")
+	stringattr.Get(m.BackchannelLogoutURL, settings, "backChannelLogoutUrl")
+	stringattr.Get(m.CustomIDPInitiatedLoginPageURL, settings, "customIdpInitiatedLoginPageUrl")
 
 	stringattr.Get(m.ClientID, settings, "clientId")
 	stringattr.Get(m.ClientSecret, settings, "clientSecret")
@@ -82,6 +90,7 @@ func (m *OIDCModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.Get(m.DeviceCodeDisabled, settings, "deviceCodeDisabled")
 	boolattr.Get(m.ForcePkce, settings, "forcePkce")
 	stringattr.Get(m.DefaultAudience, settings, "defaultAudience")
+	stringattr.Get(m.TrustedAppsAudience, settings, "trustedAppsAudience")
 
 	data := sharedApplicationData(h, m.ID, m.Name, m.Description, m.Logo, m.Disabled)
 	data["oidc"] = settings
@@ -95,6 +104,8 @@ func (m *OIDCModel) SetValues(h *helpers.Handler, data map[string]any) {
 		stringattr.Nil(&m.LoginPageURL) // XXX reset by the backend on response for now
 		strlistattr.Set(&m.Claims, settings, "claims", h)
 		boolattr.Set(&m.ForceAuthentication, settings, "forceAuthentication")
+		stringattr.Set(&m.BackchannelLogoutURL, settings, "backChannelLogoutUrl")
+		stringattr.Set(&m.CustomIDPInitiatedLoginPageURL, settings, "customIdpInitiatedLoginPageUrl")
 
 		stringattr.Set(&m.ClientID, settings, "clientId")
 		stringattr.Set(&m.ClientSecret, settings, "clientSecret")
@@ -107,6 +118,7 @@ func (m *OIDCModel) SetValues(h *helpers.Handler, data map[string]any) {
 		boolattr.Set(&m.DeviceCodeDisabled, settings, "deviceCodeDisabled")
 		boolattr.Set(&m.ForcePkce, settings, "forcePkce")
 		stringattr.Set(&m.DefaultAudience, settings, "defaultAudience")
+		stringattr.Set(&m.TrustedAppsAudience, settings, "trustedAppsAudience")
 	}
 	listattr.SetMatchingNames(&m.Permissions, data, "permissions", "name", h)
 	listattr.SetMatchingNames(&m.Roles, data, "roles", "name", h)


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/17311

## Description
- Adds `backchannel_logout_url` to `oidc_applications` — the OIDC Back-Channel Logout notification URL. This is the direct ask in the issue: the setting was not manageable via Terraform, and worse, `terraform apply` **reset a manually-configured value** because the snapshot import full-replaces the application's OIDC settings and the provider never sent the field.
- Adds `custom_idp_initiated_login_page_url` and `trusted_apps_audience`, which suffered from the exact same silent-reset problem (present in the snapshot, absent from the provider model).
- Extends the `default_audience` validator with the `appId` and `empty` values the backend already accepts, and updates its documentation accordingly.

No backend changes are needed — the project snapshot already round-trips all of these fields (`backChannelLogoutUrl`, `customIdpInitiatedLoginPageUrl`, `trustedAppsAudience` under the application's `oidc` settings).

Remaining known gaps (not in this PR): the OIDC application snapshot also carries `jwtBearerSettings`, `sessionSettings`, and `mtlsClientAuthMethods`, which are still not modeled by the provider and are therefore still reset on apply for anyone who set them manually. Those need nested schema design and are left for a follow-up.

## Must
- [x] Acceptance Tests
- [x] Schema Compatibility
- [x] Documentation Updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)