### PR TITLE
fix(oauth): validate system provider own-account attributes on initial create

### DIFF
--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -160,6 +160,21 @@ func TestAuthentication(t *testing.T) {
 			Config: p.Config(`
 				authentication = {
 					oauth = {
+						system = {
+							google = {
+								allowed_grant_types = ["authorization_code"]
+								scopes = ["openid", "email", "profile"]
+							}
+						}
+					}
+				}
+			`),
+			ExpectError: regexp.MustCompile(`Set a client_id and client_secret`),
+		},
+		resource.TestStep{
+			Config: p.Config(`
+				authentication = {
+					oauth = {
 						custom = {
 							mobile_ios = {
 								allowed_grant_types = ["authorization_code", "implicit"]

--- a/internal/models/project/authentication/oauth.go
+++ b/internal/models/project/authentication/oauth.go
@@ -143,10 +143,16 @@ func ensureRequiredCustomProviderField(h *helpers.Handler, field attr.Value, fie
 
 func ensureSystemProvider(h *helpers.Handler, provider objattr.Type[OAuthProviderModel], name string) {
 	m, _ := provider.ToObject(h.Ctx)
-	if m == nil || helpers.HasUnknownValues(m.ClientID, m.ClientSecret) {
-		return // skip validation if there are unknown values
+	if m == nil {
+		return
 	}
 
+	// this runs at apply time, where a client_id or client_secret that's still unknown can only
+	// mean the attribute wasn't set in the configuration and has no prior state value (initial
+	// create), so treat unknowns as empty rather than skipping the checks below — otherwise a
+	// configuration with own-account-only attributes but no credentials passes through to the
+	// backend, which silently ignores those attributes and causes Terraform to abort with an
+	// opaque "inconsistent result after apply" error when the applied state doesn't match the plan
 	ownAccount := m.ClientID.ValueString() != ""
 	if ownAccount {
 		if name != "apple" {


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/17416

## Description
- Creating a `descope_project` that configures a system OAuth provider (e.g. Google) with own-account-only attributes such as `scopes` but **without** `client_id`/`client_secret` failed on a fresh `terraform apply` with the opaque framework abort `.authentication: inconsistent values for sensitive attribute`.
- Root cause chain: on initial create `client_id` is Optional+Computed with no default and no prior state, so it plans as *unknown*. `ensureSystemProvider` skipped **all** validation when `client_id`/`client_secret` were unknown, so the intended "Set a client_id and client_secret …" error never fired and the request went through with `useSelfAccount: false`. The backend accepts such requests but silently overrides `scopes`/`manage_provider_tokens`/`callback_domain` with the stored settings for non-self-account system providers, so the re-exported state no longer matched the plan and Terraform Core aborted (the mismatched field was `scopes`; Core reports it vaguely because `authentication` contains sensitive-marked values).
- Fix: `ensureSystemProvider` only runs at apply time (`Values` is called from Create/Update), where an unknown `client_id`/`client_secret` can only mean the attribute wasn't set in the configuration — so treat unknowns as empty and run the checks instead of skipping them. `ValueString()` on unknown returns `""` and `Scopes.IsEmpty()` is `true` for unknown lists, so configurations that simply omit these attributes are unaffected.
- On day-2 applies the state `client_id` is a known empty string and the validation already fired correctly, so this closes the create-only hole.

## Must
- [x] Acceptance Tests
- [x] Schema Compatibility
- [ ] Documentation Updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)