### PR TITLE
feat(authentication): add allow_unverified_recipients option to terrafor

### DIFF
--- a/docs/raw/project/authentication/enchantedlink.md
+++ b/docs/raw/project/authentication/enchantedlink.md
@@ -33,6 +33,16 @@ The URL to redirect users to after they log in using the enchanted link.
 
 
 
+allow_unverified_recipients
+---------------------------
+
+- Type: `bool`
+
+By default, enchanted links are only sent to verified email addresses. Enabling this allows
+sending them to unverified email addresses as well, which may increase the risk of spam and fraud.
+
+
+
 email_service
 -------------
 

--- a/docs/raw/project/authentication/magiclink.md
+++ b/docs/raw/project/authentication/magiclink.md
@@ -33,6 +33,16 @@ The URL to redirect users to after they log in using the magic link.
 
 
 
+allow_unverified_recipients
+---------------------------
+
+- Type: `bool`
+
+By default, magic links are only sent to verified email addresses or phone numbers. Enabling this
+allows sending them to unverified email addresses or phone numbers as well, which may increase the risk of spam and fraud.
+
+
+
 email_service
 -------------
 

--- a/docs/raw/project/authentication/otp.md
+++ b/docs/raw/project/authentication/otp.md
@@ -33,6 +33,16 @@ The amount of time that an OTP code will be valid for.
 
 
 
+allow_unverified_recipients
+---------------------------
+
+- Type: `bool`
+
+By default, OTP codes are only sent to verified email addresses or phone numbers. Enabling this
+allows sending them to unverified email addresses or phone numbers as well, which may increase the risk of spam and fraud.
+
+
+
 email_service
 -------------
 

--- a/docs/raw/project/authentication/password.md
+++ b/docs/raw/project/authentication/password.md
@@ -193,6 +193,16 @@ whether a user already exists.
 
 
 
+allow_unverified_recipients
+---------------------------
+
+- Type: `bool`
+
+By default, password reset emails are only sent to verified email addresses. Enabling this allows
+sending them to unverified email addresses as well, which may increase the risk of spam and fraud.
+
+
+
 email_service
 -------------
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -707,6 +707,7 @@ Optional:
 
 Optional:
 
+- `allow_unverified_recipients` (Boolean) By default, enchanted links are only sent to verified email addresses. Enabling this allows sending them to unverified email addresses as well, which may increase the risk of spam and fraud.
 - `disabled` (Boolean) Setting this to `true` will disallow using this authentication method directly via API and SDK calls. Note that this does not affect authentication flows that are configured to use this authentication method.
 - `email_service` (Attributes) Settings related to sending emails as part of the enchanted link authentication. (see [below for nested schema](#nestedatt--authentication--enchanted_link--email_service))
 - `expiration_time` (String) How long the enchanted link remains valid before it expires.
@@ -750,6 +751,7 @@ Read-Only:
 
 Optional:
 
+- `allow_unverified_recipients` (Boolean) By default, magic links are only sent to verified email addresses or phone numbers. Enabling this allows sending them to unverified email addresses or phone numbers as well, which may increase the risk of spam and fraud.
 - `disabled` (Boolean) Setting this to `true` will disallow using this authentication method directly via API and SDK calls. Note that this does not affect authentication flows that are configured to use this authentication method.
 - `email_service` (Attributes) Settings related to sending emails as part of the magic link authentication. (see [below for nested schema](#nestedatt--authentication--magic_link--email_service))
 - `expiration_time` (String) How long the magic link remains valid before it expires.
@@ -1409,6 +1411,7 @@ Required:
 
 Optional:
 
+- `allow_unverified_recipients` (Boolean) By default, OTP codes are only sent to verified email addresses or phone numbers. Enabling this allows sending them to unverified email addresses or phone numbers as well, which may increase the risk of spam and fraud.
 - `disabled` (Boolean) Setting this to `true` will disallow using this authentication method directly via API and SDK calls. Note that this does not affect authentication flows that are configured to use this authentication method.
 - `domain` (String) The domain to embed in OTP messages.
 - `email_service` (Attributes) Settings related to sending emails with OTP codes. (see [below for nested schema](#nestedatt--authentication--otp--email_service))
@@ -1523,6 +1526,7 @@ Optional:
 
 Optional:
 
+- `allow_unverified_recipients` (Boolean) By default, password reset emails are only sent to verified email addresses. Enabling this allows sending them to unverified email addresses as well, which may increase the risk of spam and fraud.
 - `any_letter` (Boolean) Whether passwords must contain at least one letter, either uppercase or lowercase.
 - `disabled` (Boolean) Setting this to `true` will disallow using this authentication method directly via API and SDK calls. Note that this does not affect authentication flows that are configured to use this authentication method.
 - `disallow_email_match` (Boolean) Whether to reject passwords that match the user's email address or its local-part (the segment before `@`), case-insensitively. The check is skipped if the user's email is not known at validation time.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -399,7 +399,9 @@ var docsEnchantedLink = map[string]string{
 		"configured to use this authentication method.",
 	"expiration_time": "How long the enchanted link remains valid before it expires.",
 	"redirect_url":    "The URL to redirect users to after they log in using the enchanted link.",
-	"email_service":   "Settings related to sending emails as part of the enchanted link authentication.",
+	"allow_unverified_recipients": "By default, enchanted links are only sent to verified email addresses. Enabling this allows " +
+		"sending them to unverified email addresses as well, which may increase the risk of spam and fraud.",
+	"email_service": "Settings related to sending emails as part of the enchanted link authentication.",
 }
 
 var docsMagicLink = map[string]string{
@@ -408,8 +410,10 @@ var docsMagicLink = map[string]string{
 		"configured to use this authentication method.",
 	"expiration_time": "How long the magic link remains valid before it expires.",
 	"redirect_url":    "The URL to redirect users to after they log in using the magic link.",
-	"email_service":   "Settings related to sending emails as part of the magic link authentication.",
-	"text_service":    "Settings related to sending SMS messages as part of the magic link authentication.",
+	"allow_unverified_recipients": "By default, magic links are only sent to verified email addresses or phone numbers. Enabling this " +
+		"allows sending them to unverified email addresses or phone numbers as well, which may increase the risk of spam and fraud.",
+	"email_service": "Settings related to sending emails as part of the magic link authentication.",
+	"text_service":  "Settings related to sending SMS messages as part of the magic link authentication.",
 }
 
 var docsOAuth = map[string]string{
@@ -478,9 +482,11 @@ var docsOTP = map[string]string{
 		"configured to use this authentication method.",
 	"domain":          "The domain to embed in OTP messages.",
 	"expiration_time": "The amount of time that an OTP code will be valid for.",
-	"email_service":   "Settings related to sending emails with OTP codes.",
-	"text_service":    "Settings related to sending SMS messages with OTP codes.",
-	"voice_service":   "Settings related to voice calls with OTP codes.",
+	"allow_unverified_recipients": "By default, OTP codes are only sent to verified email addresses or phone numbers. Enabling this " +
+		"allows sending them to unverified email addresses or phone numbers as well, which may increase the risk of spam and fraud.",
+	"email_service": "Settings related to sending emails with OTP codes.",
+	"text_service":  "Settings related to sending SMS messages with OTP codes.",
+	"voice_service": "Settings related to voice calls with OTP codes.",
 }
 
 var docsPasskeys = map[string]string{
@@ -524,6 +530,8 @@ var docsPassword = map[string]string{
 	"enforce_strength": "Use zxcvbn to calculate the strength of a given password and enforce a minimum level of strength.",
 	"mask_errors": "Prevents information about user accounts from being revealed in error messages, e.g., " +
 		"whether a user already exists.",
+	"allow_unverified_recipients": "By default, password reset emails are only sent to verified email addresses. Enabling this allows " +
+		"sending them to unverified email addresses as well, which may increase the risk of spam and fraud.",
 	"email_service": "Settings related to sending password reset emails as part of the password feature.",
 }
 

--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -77,14 +77,16 @@ func TestAuthentication(t *testing.T) {
 				authentication = {
 					magic_link = {
 						expiration_time = "5 minutes"
+						allow_unverified_recipients = true
 					}
 				}
 			`),
 			Check: p.Check(map[string]any{
 				"authentication.magic_link": map[string]any{
-					"disabled":        false,
-					"redirect_url":    "https://example.com",
-					"expiration_time": "5 minutes",
+					"disabled":                    false,
+					"redirect_url":                "https://example.com",
+					"expiration_time":             "5 minutes",
+					"allow_unverified_recipients": true,
 				},
 			}),
 		},
@@ -516,6 +518,7 @@ func TestAuthentication(t *testing.T) {
 						temporary_lock_attempts = 7
 						temporary_lock_duration = "1 hour"
 						enforce_strength = "strong"
+						allow_unverified_recipients = true
 					}
 					passkeys = {
 						display_name = "Acme Login"
@@ -528,11 +531,12 @@ func TestAuthentication(t *testing.T) {
 			`),
 			Check: p.Check(map[string]any{
 				"authentication.password": map[string]any{
-					"disabled":                true,
-					"temporary_lock":          true,
-					"temporary_lock_attempts": 7,
-					"temporary_lock_duration": "1 hour",
-					"enforce_strength":        "strong",
+					"disabled":                    true,
+					"temporary_lock":              true,
+					"temporary_lock_attempts":     7,
+					"temporary_lock_duration":     "1 hour",
+					"enforce_strength":            "strong",
+					"allow_unverified_recipients": true,
 				},
 				"authentication.passkeys.display_name": "Acme Login",
 				"authentication.passkeys.android_fingerprints": []string{

--- a/internal/models/project/authentication/enchantedlink.go
+++ b/internal/models/project/authentication/enchantedlink.go
@@ -11,17 +11,19 @@ import (
 )
 
 var EnchantedLinkAttributes = map[string]schema.Attribute{
-	"disabled":        boolattr.Default(false),
-	"expiration_time": durationattr.Optional(durationattr.MinimumValue("1 minute")),
-	"redirect_url":    stringattr.Optional(),
-	"email_service":   objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
+	"disabled":                    boolattr.Default(false),
+	"expiration_time":             durationattr.Optional(durationattr.MinimumValue("1 minute")),
+	"redirect_url":                stringattr.Optional(),
+	"allow_unverified_recipients": boolattr.Default(false),
+	"email_service":               objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
 }
 
 type EnchantedLinkModel struct {
-	Disabled       boolattr.Type                             `tfsdk:"disabled"`
-	ExpirationTime stringattr.Type                           `tfsdk:"expiration_time"`
-	RedirectURL    stringattr.Type                           `tfsdk:"redirect_url"`
-	EmailService   objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
+	Disabled                  boolattr.Type                             `tfsdk:"disabled"`
+	ExpirationTime            stringattr.Type                           `tfsdk:"expiration_time"`
+	RedirectURL               stringattr.Type                           `tfsdk:"redirect_url"`
+	AllowUnverifiedRecipients boolattr.Type                             `tfsdk:"allow_unverified_recipients"`
+	EmailService              objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
 }
 
 func (m *EnchantedLinkModel) Values(h *helpers.Handler) map[string]any {
@@ -29,6 +31,7 @@ func (m *EnchantedLinkModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.GetNot(m.Disabled, data, "enabled")
 	durationattr.Get(m.ExpirationTime, data, "expirationTime")
 	stringattr.Get(m.RedirectURL, data, "redirectUrl")
+	boolattr.Get(m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Get(m.EmailService, data, helpers.RootKey, h)
 	return data
 }
@@ -37,6 +40,7 @@ func (m *EnchantedLinkModel) SetValues(h *helpers.Handler, data map[string]any) 
 	boolattr.SetNot(&m.Disabled, data, "enabled")
 	durationattr.Set(&m.ExpirationTime, data, "expirationTime")
 	stringattr.Set(&m.RedirectURL, data, "redirectUrl")
+	boolattr.Set(&m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Set(&m.EmailService, data, helpers.RootKey, h)
 }
 

--- a/internal/models/project/authentication/magiclink.go
+++ b/internal/models/project/authentication/magiclink.go
@@ -11,19 +11,21 @@ import (
 )
 
 var MagicLinkAttributes = map[string]schema.Attribute{
-	"disabled":        boolattr.Default(false),
-	"expiration_time": durationattr.Optional(durationattr.MinimumValue("1 minute")),
-	"redirect_url":    stringattr.Optional(),
-	"email_service":   objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
-	"text_service":    objattr.Optional[templates.TextServiceModel](templates.TextServiceAttributes, templates.TextServiceValidator),
+	"disabled":                    boolattr.Default(false),
+	"expiration_time":             durationattr.Optional(durationattr.MinimumValue("1 minute")),
+	"redirect_url":                stringattr.Optional(),
+	"allow_unverified_recipients": boolattr.Default(false),
+	"email_service":               objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
+	"text_service":                objattr.Optional[templates.TextServiceModel](templates.TextServiceAttributes, templates.TextServiceValidator),
 }
 
 type MagicLinkModel struct {
-	Disabled       boolattr.Type                             `tfsdk:"disabled"`
-	ExpirationTime stringattr.Type                           `tfsdk:"expiration_time"`
-	RedirectURL    stringattr.Type                           `tfsdk:"redirect_url"`
-	EmailService   objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
-	TextService    objattr.Type[templates.TextServiceModel]  `tfsdk:"text_service"`
+	Disabled                  boolattr.Type                             `tfsdk:"disabled"`
+	ExpirationTime            stringattr.Type                           `tfsdk:"expiration_time"`
+	RedirectURL               stringattr.Type                           `tfsdk:"redirect_url"`
+	AllowUnverifiedRecipients boolattr.Type                             `tfsdk:"allow_unverified_recipients"`
+	EmailService              objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
+	TextService               objattr.Type[templates.TextServiceModel]  `tfsdk:"text_service"`
 }
 
 func (m *MagicLinkModel) Values(h *helpers.Handler) map[string]any {
@@ -31,6 +33,7 @@ func (m *MagicLinkModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.GetNot(m.Disabled, data, "enabled")
 	durationattr.Get(m.ExpirationTime, data, "expirationTime")
 	stringattr.Get(m.RedirectURL, data, "redirectUrl")
+	boolattr.Get(m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Get(m.EmailService, data, helpers.RootKey, h)
 	objattr.Get(m.TextService, data, helpers.RootKey, h)
 	return data
@@ -40,6 +43,7 @@ func (m *MagicLinkModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.SetNot(&m.Disabled, data, "enabled")
 	durationattr.Set(&m.ExpirationTime, data, "expirationTime")
 	stringattr.Set(&m.RedirectURL, data, "redirectUrl")
+	boolattr.Set(&m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Set(&m.EmailService, data, helpers.RootKey, h)
 	objattr.Set(&m.TextService, data, helpers.RootKey, h)
 }

--- a/internal/models/project/authentication/otp.go
+++ b/internal/models/project/authentication/otp.go
@@ -11,21 +11,23 @@ import (
 )
 
 var OTPAttributes = map[string]schema.Attribute{
-	"disabled":        boolattr.Default(false),
-	"domain":          stringattr.Optional(),
-	"expiration_time": durationattr.Optional(durationattr.MinimumValue("1 minute")),
-	"email_service":   objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
-	"text_service":    objattr.Optional[templates.TextServiceModel](templates.TextServiceAttributes, templates.TextServiceValidator),
-	"voice_service":   objattr.Optional[templates.VoiceServiceModel](templates.VoiceServiceAttributes, templates.VoiceServiceValidator),
+	"disabled":                    boolattr.Default(false),
+	"domain":                      stringattr.Optional(),
+	"expiration_time":             durationattr.Optional(durationattr.MinimumValue("1 minute")),
+	"allow_unverified_recipients": boolattr.Default(false),
+	"email_service":               objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
+	"text_service":                objattr.Optional[templates.TextServiceModel](templates.TextServiceAttributes, templates.TextServiceValidator),
+	"voice_service":               objattr.Optional[templates.VoiceServiceModel](templates.VoiceServiceAttributes, templates.VoiceServiceValidator),
 }
 
 type OTPModel struct {
-	Disabled       boolattr.Type                             `tfsdk:"disabled"`
-	Domain         stringattr.Type                           `tfsdk:"domain"`
-	ExpirationTime stringattr.Type                           `tfsdk:"expiration_time"`
-	EmailService   objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
-	TextService    objattr.Type[templates.TextServiceModel]  `tfsdk:"text_service"`
-	VoiceService   objattr.Type[templates.VoiceServiceModel] `tfsdk:"voice_service"`
+	Disabled                  boolattr.Type                             `tfsdk:"disabled"`
+	Domain                    stringattr.Type                           `tfsdk:"domain"`
+	ExpirationTime            stringattr.Type                           `tfsdk:"expiration_time"`
+	AllowUnverifiedRecipients boolattr.Type                             `tfsdk:"allow_unverified_recipients"`
+	EmailService              objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
+	TextService               objattr.Type[templates.TextServiceModel]  `tfsdk:"text_service"`
+	VoiceService              objattr.Type[templates.VoiceServiceModel] `tfsdk:"voice_service"`
 }
 
 func (m *OTPModel) Values(h *helpers.Handler) map[string]any {
@@ -33,6 +35,7 @@ func (m *OTPModel) Values(h *helpers.Handler) map[string]any {
 	boolattr.GetNot(m.Disabled, data, "enabled")
 	stringattr.Get(m.Domain, data, "domain")
 	durationattr.Get(m.ExpirationTime, data, "expirationTime")
+	boolattr.Get(m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Get(m.EmailService, data, helpers.RootKey, h)
 	objattr.Get(m.TextService, data, helpers.RootKey, h)
 	objattr.Get(m.VoiceService, data, helpers.RootKey, h)
@@ -43,6 +46,7 @@ func (m *OTPModel) SetValues(h *helpers.Handler, data map[string]any) {
 	boolattr.SetNot(&m.Disabled, data, "enabled")
 	stringattr.Set(&m.Domain, data, "domain")
 	durationattr.Set(&m.ExpirationTime, data, "expirationTime")
+	boolattr.Set(&m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Set(&m.EmailService, data, helpers.RootKey, h)
 	objattr.Set(&m.TextService, data, helpers.RootKey, h)
 	objattr.Set(&m.VoiceService, data, helpers.RootKey, h)

--- a/internal/models/project/authentication/password.go
+++ b/internal/models/project/authentication/password.go
@@ -14,51 +14,53 @@ import (
 )
 
 var PasswordAttributes = map[string]schema.Attribute{
-	"disabled":                boolattr.Default(false),
-	"expiration":              boolattr.Optional(),
-	"expiration_weeks":        intattr.Optional(int64validator.Between(1, 999)),
-	"lock":                    boolattr.Optional(),
-	"lock_attempts":           intattr.Optional(int64validator.Between(2, 10)),
-	"temporary_lock":          boolattr.Default(false),
-	"temporary_lock_attempts": intattr.Default(3, int64validator.Between(1, 10)),
-	"temporary_lock_duration": durationattr.Default("5 minutes", durationattr.MinimumValue("1 minute"), durationattr.MaximumValue("24 hours")),
-	"lowercase":               boolattr.Optional(),
-	"min_length":              intattr.Optional(int64validator.Between(4, 64)),
-	"non_alphanumeric":        boolattr.Optional(),
-	"number":                  boolattr.Optional(),
-	"reuse":                   boolattr.Optional(),
-	"reuse_amount":            intattr.Optional(int64validator.Between(1, 50)),
-	"uppercase":               boolattr.Optional(),
-	"any_letter":              boolattr.Optional(),
-	"disallowed_characters":   stringattr.Optional(),
-	"disallow_email_match":    boolattr.Optional(),
-	"enforce_strength":        stringattr.Default("none", stringvalidator.OneOf("none", "very_weak", "weak", "average", "strong", "very_strong")),
-	"mask_errors":             boolattr.Default(false),
-	"email_service":           objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
+	"disabled":                    boolattr.Default(false),
+	"expiration":                  boolattr.Optional(),
+	"expiration_weeks":            intattr.Optional(int64validator.Between(1, 999)),
+	"lock":                        boolattr.Optional(),
+	"lock_attempts":               intattr.Optional(int64validator.Between(2, 10)),
+	"temporary_lock":              boolattr.Default(false),
+	"temporary_lock_attempts":     intattr.Default(3, int64validator.Between(1, 10)),
+	"temporary_lock_duration":     durationattr.Default("5 minutes", durationattr.MinimumValue("1 minute"), durationattr.MaximumValue("24 hours")),
+	"lowercase":                   boolattr.Optional(),
+	"min_length":                  intattr.Optional(int64validator.Between(4, 64)),
+	"non_alphanumeric":            boolattr.Optional(),
+	"number":                      boolattr.Optional(),
+	"reuse":                       boolattr.Optional(),
+	"reuse_amount":                intattr.Optional(int64validator.Between(1, 50)),
+	"uppercase":                   boolattr.Optional(),
+	"any_letter":                  boolattr.Optional(),
+	"disallowed_characters":       stringattr.Optional(),
+	"disallow_email_match":        boolattr.Optional(),
+	"enforce_strength":            stringattr.Default("none", stringvalidator.OneOf("none", "very_weak", "weak", "average", "strong", "very_strong")),
+	"mask_errors":                 boolattr.Default(false),
+	"allow_unverified_recipients": boolattr.Default(false),
+	"email_service":               objattr.Optional[templates.EmailServiceModel](templates.EmailServiceAttributes, templates.EmailServiceValidator),
 }
 
 type PasswordModel struct {
-	Disabled              boolattr.Type                             `tfsdk:"disabled"`
-	Expiration            boolattr.Type                             `tfsdk:"expiration"`
-	ExpirationWeeks       intattr.Type                              `tfsdk:"expiration_weeks"`
-	Lock                  boolattr.Type                             `tfsdk:"lock"`
-	LockAttempts          intattr.Type                              `tfsdk:"lock_attempts"`
-	TemporaryLock         boolattr.Type                             `tfsdk:"temporary_lock"`
-	TemporaryLockAttempts intattr.Type                              `tfsdk:"temporary_lock_attempts"`
-	TemporaryLockDuration durationattr.Type                         `tfsdk:"temporary_lock_duration"`
-	Lowercase             boolattr.Type                             `tfsdk:"lowercase"`
-	MinLength             intattr.Type                              `tfsdk:"min_length"`
-	NonAlphanumeric       boolattr.Type                             `tfsdk:"non_alphanumeric"`
-	Number                boolattr.Type                             `tfsdk:"number"`
-	Reuse                 boolattr.Type                             `tfsdk:"reuse"`
-	ReuseAmount           intattr.Type                              `tfsdk:"reuse_amount"`
-	Uppercase             boolattr.Type                             `tfsdk:"uppercase"`
-	AnyLetter             boolattr.Type                             `tfsdk:"any_letter"`
-	DisallowedCharacters  stringattr.Type                           `tfsdk:"disallowed_characters"`
-	DisallowEmailMatch    boolattr.Type                             `tfsdk:"disallow_email_match"`
-	EnforceStrength       stringattr.Type                           `tfsdk:"enforce_strength"`
-	MaskErrors            boolattr.Type                             `tfsdk:"mask_errors"`
-	EmailService          objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
+	Disabled                  boolattr.Type                             `tfsdk:"disabled"`
+	Expiration                boolattr.Type                             `tfsdk:"expiration"`
+	ExpirationWeeks           intattr.Type                              `tfsdk:"expiration_weeks"`
+	Lock                      boolattr.Type                             `tfsdk:"lock"`
+	LockAttempts              intattr.Type                              `tfsdk:"lock_attempts"`
+	TemporaryLock             boolattr.Type                             `tfsdk:"temporary_lock"`
+	TemporaryLockAttempts     intattr.Type                              `tfsdk:"temporary_lock_attempts"`
+	TemporaryLockDuration     durationattr.Type                         `tfsdk:"temporary_lock_duration"`
+	Lowercase                 boolattr.Type                             `tfsdk:"lowercase"`
+	MinLength                 intattr.Type                              `tfsdk:"min_length"`
+	NonAlphanumeric           boolattr.Type                             `tfsdk:"non_alphanumeric"`
+	Number                    boolattr.Type                             `tfsdk:"number"`
+	Reuse                     boolattr.Type                             `tfsdk:"reuse"`
+	ReuseAmount               intattr.Type                              `tfsdk:"reuse_amount"`
+	Uppercase                 boolattr.Type                             `tfsdk:"uppercase"`
+	AnyLetter                 boolattr.Type                             `tfsdk:"any_letter"`
+	DisallowedCharacters      stringattr.Type                           `tfsdk:"disallowed_characters"`
+	DisallowEmailMatch        boolattr.Type                             `tfsdk:"disallow_email_match"`
+	EnforceStrength           stringattr.Type                           `tfsdk:"enforce_strength"`
+	MaskErrors                boolattr.Type                             `tfsdk:"mask_errors"`
+	AllowUnverifiedRecipients boolattr.Type                             `tfsdk:"allow_unverified_recipients"`
+	EmailService              objattr.Type[templates.EmailServiceModel] `tfsdk:"email_service"`
 }
 
 func (m *PasswordModel) Values(h *helpers.Handler) map[string]any {
@@ -89,6 +91,7 @@ func (m *PasswordModel) Values(h *helpers.Handler) map[string]any {
 		data["passwordStrengthScore"] = strengthScoreFromString(m.EnforceStrength.ValueString())
 	}
 	boolattr.Get(m.MaskErrors, data, "maskError")
+	boolattr.Get(m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Get(m.EmailService, data, helpers.RootKey, h)
 	return data
 }
@@ -119,6 +122,7 @@ func (m *PasswordModel) SetValues(h *helpers.Handler, data map[string]any) {
 		m.EnforceStrength = stringattr.Value(strengthStringFromScore(int(score)))
 	}
 	boolattr.Set(&m.MaskErrors, data, "maskError")
+	boolattr.Set(&m.AllowUnverifiedRecipients, data, "allowUnverifiedRecipients")
 	objattr.Set(&m.EmailService, data, helpers.RootKey, h)
 }
 


### PR DESCRIPTION
Fixes descope/etc#17913

[View Shuni run](https://shuni.descope.ai/sessions?sandbox=i5mlp66wm86gn1ngk7jfv)

## Summary

Fixed the missing **"Allow unverified recipient addresses/numbers"** option by adding a new `allow_unverified_recipients` boolean attribute (default `false`) to the four authentication method schemas where Descope's console exposes this setting:

- `otp` (`internal/models/project/authentication/otp.go`)
- `magic_link` (`magiclink.go`)
- `enchanted_link` (`enchantedlink.go`)
- `password` (`password.go`, for the reset-password email flow)

Also updated:
- `internal/docs/docs.go` — attribute descriptions (this file is normally generated by `tools/terragen`, but that tool requires a private connector-template repo unavailable in this sandbox, so I hand-edited it directly — it's just a data map, safe to edit by hand)
- `docs/raw/project/authentication/*.md` — source-of-truth doc fragments, kept in sync for future regeneration
- `docs/resources/project.md` — registry-facing docs (regenerating via `tfplugindocs` failed here because it needs to download the Terraform CLI, which failed on an expired HashiCorp signing key in this sandbox — I updated the file by hand instead)
- `authentication_test.go` — extended existing acceptance test steps for `magic_link` and `password` to cover the new field

One caveat worth flagging: the wire-level JSON key (`allowUnverifiedRecipients`) isn't documented anywhere public — this provider talks to a private Descope config API. I inferred the name from this repo's established convention (e.g. `allowOverrideRoles`, `markEmailAsUnverified` in `sso.go`) rather than verifying against a live project, since no Descope credentials were available in this sandbox. Everything else (schema wiring, docs, tests) is complete and verified.

**Verification:** `go build`, `go vet`, `golangci-lint` (0 issues), and `go test ./internal/...` all pass. Acceptance tests (`TF_ACC=1`) were extended but not run — they need live Descope credentials not present here.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*