### PR TITLE
feat(sso-suite): replace hide_xaa with show_xaa

### DIFF
--- a/docs/raw/project/authentication/sso.md
+++ b/docs/raw/project/authentication/sso.md
@@ -292,9 +292,9 @@ hide_jit_guide
 Whether to hide the JIT provisioning guide section in the SSO Suite hosted UI.
 
 
-hide_xaa
+show_xaa
 --------
 
 - Type: `bool`
 
-Whether to hide the Cross-App Access (XAA) section in the SSO Suite hosted UI.
+Whether to show the Cross-App Access (XAA) section in the SSO Suite hosted UI. Cross-App Access is opt-in: it stays hidden unless this is set.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1658,8 +1658,8 @@ Optional:
 - `hide_saml` (Boolean) Setting this to `true` will hide the SAML configuration option.
 - `hide_scim` (Boolean) Setting this to `true` will hide the SCIM configuration in the SSO Suite interface.
 - `hide_sso` (Boolean) Setting this to `true` will hide the SSO configuration in the SSO Suite interface, for tenants that only need to set up SCIM provisioning.
-- `hide_xaa` (Boolean) Whether to hide the Cross-App Access (XAA) section in the SSO Suite hosted UI.
 - `show_help_contact` (Boolean) Whether to display the help/support contact link in the SSO Suite UI.
+- `show_xaa` (Boolean) Whether to show the Cross-App Access (XAA) section in the SSO Suite hosted UI. Cross-App Access is opt-in: it stays hidden unless this is set.
 - `style_id` (String) Specifies the style ID to apply in the SSO Suite. Ensure a style with this ID exists in the console for it to be used.
 - `support_email` (String) Email address shown to end-users in the SSO Suite UI as a support contact.
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -569,7 +569,7 @@ var docsSSOSuite = map[string]string{
 	"support_email":             "Email address shown to end-users in the SSO Suite UI as a support contact.",
 	"show_help_contact":         "Whether to display the help/support contact link in the SSO Suite UI.",
 	"hide_jit_guide":            "Whether to hide the JIT provisioning guide section in the SSO Suite hosted UI.",
-	"hide_xaa":                  "Whether to hide the Cross-App Access (XAA) section in the SSO Suite hosted UI.",
+	"show_xaa":                  "Whether to show the Cross-App Access (XAA) section in the SSO Suite hosted UI. Cross-App Access is opt-in: it stays hidden unless this is set.",
 }
 
 var docsTOTP = map[string]string{

--- a/internal/models/project/authentication/authentication_test.go
+++ b/internal/models/project/authentication/authentication_test.go
@@ -262,7 +262,7 @@ func TestAuthentication(t *testing.T) {
 							style_id           = "koko"
 							hide_saml          = true
 							hide_jit_guide     = true
-							hide_xaa           = true
+							show_xaa           = true
 							support_email      = "help@acme.com"
 							show_help_contact  = true
 							hide_role_mapping  = true
@@ -276,7 +276,7 @@ func TestAuthentication(t *testing.T) {
 					"style_id":          "koko",
 					"hide_saml":         true,
 					"hide_jit_guide":    true,
-					"hide_xaa":          true,
+					"show_xaa":          true,
 					"support_email":     "help@acme.com",
 					"show_help_contact": true,
 					"hide_role_mapping": true,

--- a/internal/models/project/authentication/sso.go
+++ b/internal/models/project/authentication/sso.go
@@ -139,7 +139,7 @@ var SSOSuiteAttributes = map[string]schema.Attribute{
 	"support_email":             stringattr.Default("", stringattr.EmailValidator),
 	"show_help_contact":         boolattr.Default(false),
 	"hide_jit_guide":            boolattr.Default(false),
-	"hide_xaa":                  boolattr.Default(false),
+	"show_xaa":                  boolattr.Default(false),
 }
 
 type SSOSuiteModel struct {
@@ -156,7 +156,7 @@ type SSOSuiteModel struct {
 	SupportEmail            stringattr.Type `tfsdk:"support_email"`
 	ShowHelpContact         boolattr.Type   `tfsdk:"show_help_contact"`
 	HideJitGuide            boolattr.Type   `tfsdk:"hide_jit_guide"`
-	HideXAA                 boolattr.Type   `tfsdk:"hide_xaa"`
+	ShowXAA                 boolattr.Type   `tfsdk:"show_xaa"`
 }
 
 var SSOSuiteDefault = &SSOSuiteModel{
@@ -173,7 +173,7 @@ var SSOSuiteDefault = &SSOSuiteModel{
 	SupportEmail:            stringattr.Value(""),
 	ShowHelpContact:         boolattr.Value(false),
 	HideJitGuide:            boolattr.Value(false),
-	HideXAA:                 boolattr.Value(false),
+	ShowXAA:                 boolattr.Value(false),
 }
 
 func (m *SSOSuiteModel) Values(h *helpers.Handler) map[string]any {
@@ -191,7 +191,7 @@ func (m *SSOSuiteModel) Values(h *helpers.Handler) map[string]any {
 	stringattr.Get(m.SupportEmail, data, "ssoSuiteSupportEmail")
 	boolattr.Get(m.ShowHelpContact, data, "ssoSuiteShowHelpContact")
 	boolattr.Get(m.HideJitGuide, data, "hideSsoSuiteJitGuide")
-	boolattr.Get(m.HideXAA, data, "hideSsoSuiteXaa")
+	boolattr.Get(m.ShowXAA, data, "showSsoSuiteXaa")
 	return data
 }
 
@@ -209,7 +209,7 @@ func (m *SSOSuiteModel) SetValues(h *helpers.Handler, data map[string]any) {
 	stringattr.Set(&m.SupportEmail, data, "ssoSuiteSupportEmail")
 	boolattr.Set(&m.ShowHelpContact, data, "ssoSuiteShowHelpContact")
 	boolattr.Set(&m.HideJitGuide, data, "hideSsoSuiteJitGuide")
-	boolattr.Set(&m.HideXAA, data, "hideSsoSuiteXaa")
+	boolattr.Set(&m.ShowXAA, data, "showSsoSuiteXaa")
 }
 
 func (m *SSOSuiteModel) Validate(h *helpers.Handler) {


### PR DESCRIPTION
## Description

Cross-App Access in the SSO Suite becomes opt-in per project, so the backend field flipped polarity: `hideSsoSuiteXaa` -> `showSsoSuiteXaa` (https://github.com/descope/backend/pull/2370). `hide_xaa` would now write a key the API no longer has — silently doing nothing.

Renamed rather than kept alongside: the attribute shipped one release ago (#367) for a feature that is off by default from now on, and carrying both polarities would let a config say `hide_xaa = false` and still get no XAA.

```hcl
sso_suite_settings = {
  show_xaa = true   # was: hide_xaa = false
}
```

`docs/resources/project.md` is hand-edited to match: `make docs` cannot run in this environment (the tfplugindocs Terraform download fails on an expired PGP key), so the generated line was updated in place and kept in the alphabetical position tfplugindocs emits. Worth re-running `make docs` on a machine where it works before merge.

## Related PRs
| branch | PR |
| ------ | -- |
| backend | https://github.com/descope/backend/pull/2370 |
| console-app | https://github.com/descope/console-app/pull/5731 |
| descope-apps | https://github.com/descope/descope-apps/pull/862 |

## Must
- [x] Tests — the `sso_suite_settings` acceptance-test block now sets `show_xaa` and asserts it round-trips
