### PR TITLE
feat(governance): expose Agentic Governance Suite settings on descope_project

### DIFF
--- a/internal/models/project/governance/governance.go
+++ b/internal/models/project/governance/governance.go
@@ -1,0 +1,44 @@
+package governance
+
+import (
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/boolattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
+	"github.com/descope/terraform-provider-descope/internal/models/helpers"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// Agentic Governance Suite settings. Unlike admin_portal these are flat -- the
+// snapshot file's whole body is the object, with no "config" wrapper.
+var GovernanceAttributes = map[string]schema.Attribute{
+	"configured":     boolattr.Default(false),
+	"auto_approval":  boolattr.Default(false),
+	"suite_disabled": boolattr.Default(false),
+	// Every field the suite has is modelled here on purpose. The infra layer
+	// replaces governance.json whole rather than merging, so a field left out of
+	// the model is written back as its zero value -- omitting the logo would blank
+	// a configured one on the next apply.
+	"logo": stringattr.Default(""),
+}
+
+type GovernanceModel struct {
+	Configured    boolattr.Type   `tfsdk:"configured"`
+	AutoApproval  boolattr.Type   `tfsdk:"auto_approval"`
+	SuiteDisabled boolattr.Type   `tfsdk:"suite_disabled"`
+	Logo          stringattr.Type `tfsdk:"logo"`
+}
+
+func (m *GovernanceModel) Values(_ *helpers.Handler) map[string]any {
+	data := map[string]any{}
+	boolattr.Get(m.Configured, data, "configured")
+	boolattr.Get(m.AutoApproval, data, "autoApproval")
+	boolattr.Get(m.SuiteDisabled, data, "suiteDisabled")
+	stringattr.Get(m.Logo, data, "logo")
+	return data
+}
+
+func (m *GovernanceModel) SetValues(_ *helpers.Handler, data map[string]any) {
+	boolattr.Set(&m.Configured, data, "configured")
+	boolattr.Set(&m.AutoApproval, data, "autoApproval")
+	boolattr.Set(&m.SuiteDisabled, data, "suiteDisabled")
+	stringattr.Set(&m.Logo, data, "logo")
+}

--- a/internal/models/project/governance/governance_test.go
+++ b/internal/models/project/governance/governance_test.go
@@ -1,0 +1,74 @@
+package governance_test
+
+import (
+	"testing"
+
+	"github.com/descope/terraform-provider-descope/tools/testacc"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestGovernance(t *testing.T) {
+	p := testacc.Project(t)
+	testacc.Run(t,
+		resource.TestStep{
+			// A project that never configured AGS carries no governance.json, so the
+			// attribute reads back unset rather than as a zeroed object.
+			Config: p.Config(),
+			Check: p.Check(map[string]any{
+				"governance": testacc.AttributeIsNotSet,
+			}),
+		},
+		resource.TestStep{
+			// Everything set at once, including suite_disabled true. That one is the
+			// suite kill switch and the only field here whose meaningful value is
+			// false-y, so it is what a "drop empty fields" pass would silently lose.
+			Config: p.Config(`
+				governance = {
+					configured     = true
+					auto_approval  = true
+					suite_disabled = true
+					logo           = "data:image/png;base64,iVBORw0KGgo="
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"governance.configured":     true,
+				"governance.auto_approval":  true,
+				"governance.suite_disabled": true,
+				"governance.logo":           "data:image/png;base64,iVBORw0KGgo=",
+			}),
+		},
+		resource.TestStep{
+			// Flipping the booleans back off has to stick. The write path replaces the
+			// file whole, so a false that fails to round-trip would read as "never set"
+			// and leave the previous true in place.
+			Config: p.Config(`
+				governance = {
+					configured     = true
+					auto_approval  = false
+					suite_disabled = false
+					logo           = "data:image/png;base64,iVBORw0KGgo="
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"governance.configured":     true,
+				"governance.auto_approval":  false,
+				"governance.suite_disabled": false,
+			}),
+		},
+		resource.TestStep{
+			// The logo is carried by the model rather than left out, because the infra
+			// layer replaces governance.json instead of merging: a config that omits
+			// the logo blanks whatever the console had set.
+			Config: p.Config(`
+				governance = {
+					configured = true
+					logo       = ""
+				}
+			`),
+			Check: p.Check(map[string]any{
+				"governance.configured": true,
+				"governance.logo":       "",
+			}),
+		},
+	)
+}

--- a/internal/models/project/project.go
+++ b/internal/models/project/project.go
@@ -14,6 +14,7 @@ import (
 	"github.com/descope/terraform-provider-descope/internal/models/project/authorization"
 	"github.com/descope/terraform-provider-descope/internal/models/project/connectors"
 	"github.com/descope/terraform-provider-descope/internal/models/project/flows"
+	"github.com/descope/terraform-provider-descope/internal/models/project/governance"
 	"github.com/descope/terraform-provider-descope/internal/models/project/jwttemplates"
 	"github.com/descope/terraform-provider-descope/internal/models/project/lists"
 	"github.com/descope/terraform-provider-descope/internal/models/project/settings"
@@ -40,6 +41,7 @@ var ProjectAttributes = map[string]schema.Attribute{
 	"widgets":          mapattr.Optional[widgets.WidgetModel](widgets.WidgetAttributes, widgets.WidgetIDValidator),
 	"lists":            listattr.Default[lists.ListModel](lists.ListAttributes, lists.ListValidator, lists.ListsModifier),
 	"admin_portal":     objattr.Default[adminportal.AdminPortalModel](nil, adminportal.AdminPortalAttributes, adminportal.AdminPortalValidator),
+	"governance":       objattr.Default[governance.GovernanceModel](nil, governance.GovernanceAttributes),
 }
 
 type ProjectModel struct {
@@ -60,6 +62,7 @@ type ProjectModel struct {
 	Widgets        mapattr.Type[widgets.WidgetModel]                `tfsdk:"widgets"`
 	Lists          listattr.Type[lists.ListModel]                   `tfsdk:"lists"`
 	AdminPortal    objattr.Type[adminportal.AdminPortalModel]       `tfsdk:"admin_portal"`
+	Governance     objattr.Type[governance.GovernanceModel]         `tfsdk:"governance"`
 }
 
 func (m *ProjectModel) Values(h *helpers.Handler) map[string]any {
@@ -83,6 +86,7 @@ func (m *ProjectModel) Values(h *helpers.Handler) map[string]any {
 	widgets.EnsureWidgetIDs(m.Widgets, data, "widgets", h)
 	listattr.Get(m.Lists, data, "lists", h)
 	objattr.Get(m.AdminPortal, data, "adminportal", h)
+	objattr.Get(m.Governance, data, "governance", h)
 	return data
 }
 
@@ -115,6 +119,7 @@ func (m *ProjectModel) SetValues(h *helpers.Handler, data map[string]any) {
 	}
 	listattr.SetMatchingNames(&m.Lists, data, "lists", "name", h)
 	objattr.Set(&m.AdminPortal, data, "adminportal", h)
+	objattr.Set(&m.Governance, data, "governance", h)
 }
 
 func (m *ProjectModel) CollectReferences(h *helpers.Handler) {


### PR DESCRIPTION
## what this is

**layer 3 of 3.** the terraform chain for AGS setting:

```
backend#2364 (MERGED)  env snapshot carry governance settings
backend#2435 (MERGED)  infra ProjectModel carry them  <- only thing /v1/mgmt/infra read
this PR                HCL surface on descope_project
```

provider talk to exactly one endpoint -- `internal/infra/client.go` do GET/POST/PUT/DELETE
on `/v1/mgmt/infra`, nothing else. so layer 2 was the price of admission and this is the
part customer actually write.

## new block

```hcl
resource "descope_project" "example" {
  name = "..."

  governance = {
    configured     = true
    auto_approval  = false
    suite_disabled = false
    logo           = "data:image/png;base64,..."
  }
}
```

flat object, no `config` wrapper -- unlike `admin_portal`. that match `governance.json`,
whose whole body IS the object.

## why logo is modelled and not skipped

me consider leaving `logo` out. it a base64 data URI up to 2 MiB, it land in terraform
state, and it diff on every plan. tempting to omit.

**cannot.** infra `modifyFiles` do `files["governance.json"] = m.Governance` -- whole-file
**replace**, not merge. so any field the provider not model get written back as zero
value. omit logo and every `terraform apply` **blank a console-configured logo**.

same reason acceptance test flip boolean back to `false` in later step: a false that fail
to round-trip read as "never set" and leave previous `true` in place. that the failure
mode worth pinning, not the happy path.

## tests

`governance_test.go`, four step:

1. fresh project -> attribute **unset** (not zeroed object). project that never touch AGS
   carry no `governance.json`.
2. everything set, `suite_disabled = true`. that the suite **kill switch** and only field
   here whose meaningful value is false-y, so it what a "drop empty field" pass lose.
3. boolean flip back to false -> must stick.
4. `logo = ""` -> round-trip, guarding the replace-not-merge behaviour above.

## honest state -- two thing NOT done

**`make terragen` / `make docs` not run.** terragen want `DESCOPE_TEMPLATES_PATH`, not set
in my env. it also already fail on **clean main** for unrelated `vendor/modules.txt`
mismatch (verified by stashing my change and re-running). hand-writing the generated
placeholder would only drift from what the tool emit, so me leave it. **needs somebody
with the templates path to run both and commit `docs/`.**

**`make testacc` not run.** it hit a real Descope project, so it **cannot pass until
backend#2435 ship in a deployed managementservice image**. test is written and compile;
it has never executed.

what me did verify: `go build ./...` clean, `go vet` clean, `golangci-lint` repo config
**0 issues** on changed package, `gofmt` clean.

## merge order

**this must not merge before backend#2435 is deployed** -- not just merged. acceptance
test go green only once the infra field exist in a running managementservice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGfDD9SCkhWRhxpfthQRPr
