### PR TITLE
docs(styles): document that an apply no longer deletes unmanaged styles

### DIFF
--- a/docs/raw/styles/styles.md
+++ b/docs/raw/styles/styles.md
@@ -21,4 +21,8 @@ data
 
 The JSON data of the styles in their exported theme representation, defining the visual styling of
 the project's flow pages. This will usually be exported as a `.json` file from the Descope console,
-and set in the `.tf` file using the `data = file("...")` syntax.
+and set in the `.tf` file using the `data = file("...")` syntax. Applying this resource creates and
+overwrites the styles the data carries, and leaves every other style in the project untouched, so
+styles created in the console are safe from a Terraform apply. For the same reason removing a style
+from the data does not remove it from the project - delete it in the console or through the
+management API instead.

--- a/docs/resources/styles.md
+++ b/docs/resources/styles.md
@@ -17,7 +17,7 @@ Manages the styles (theme) of the project's flow pages via the exported theme JS
 
 ### Required
 
-- `data` (String) The JSON data of the styles in their exported theme representation, defining the visual styling of the project's flow pages. This will usually be exported as a `.json` file from the Descope console, and set in the `.tf` file using the `data = file("...")` syntax.
+- `data` (String) The JSON data of the styles in their exported theme representation, defining the visual styling of the project's flow pages. This will usually be exported as a `.json` file from the Descope console, and set in the `.tf` file using the `data = file("...")` syntax. Applying this resource creates and overwrites the styles the data carries, and leaves every other style in the project untouched, so styles created in the console are safe from a Terraform apply. For the same reason removing a style from the data does not remove it from the project - delete it in the console or through the management API instead.
 - `project_id` (String) The ID of the project that the styles belong to. Changing this value will require the resource to be deleted and recreated.
 
 ### Read-Only

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1912,7 +1912,11 @@ var docsStyles = map[string]string{
 		"deleted and recreated.",
 	"data": "The JSON data of the styles in their exported theme representation, defining the visual styling of " +
 		"the project's flow pages. This will usually be exported as a `.json` file from the Descope console, " +
-		"and set in the `.tf` file using the `data = file(\"...\")` syntax.",
+		"and set in the `.tf` file using the `data = file(\"...\")` syntax. Applying this resource creates and " +
+		"overwrites the styles the data carries, and leaves every other style in the project untouched, so " +
+		"styles created in the console are safe from a Terraform apply. For the same reason removing a style " +
+		"from the data does not remove it from the project - delete it in the console or through the " +
+		"management API instead.",
 }
 
 var docsTemplatesEmailTemplate = map[string]string{

--- a/internal/models/styles/styles_test.go
+++ b/internal/models/styles/styles_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/descope/terraform-provider-descope/tools/testacc"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStyles(t *testing.T) {
@@ -55,5 +57,96 @@ func TestStyles(t *testing.T) {
 			ImportStateVerifyIgnore: []string{"data"},
 		},
 		// removing the resource is a no-op that leaves the theme in place
+	)
+}
+
+// An apply must not delete styles this resource does not carry - styles created in the console are
+// invisible to Terraform, and used to be wiped by every apply.
+// See https://github.com/descope/etc/issues/12809
+func TestStylesKeepsUnmanagedStyles(t *testing.T) {
+	projectID := testacc.ProjectID(t)
+	s := testacc.Styles(t)
+
+	unmanaged := map[string]any{
+		"unmanaged-light": map[string]any{"name": "Unmanaged", "type": "flows"},
+		"unmanaged-dark":  map[string]any{"name": "Unmanaged", "type": "flows"},
+	}
+
+	// leave the project holding only the styles this test manages, whatever the outcome
+	t.Cleanup(func() {
+		if projectID == "" {
+			return
+		}
+		testacc.OutOfBandPost(t, projectID, "/v2/mgmt/theme/import", map[string]any{
+			"theme":            map[string]any{"styles": map[string]any{"light": map[string]any{}, "dark": map[string]any{}}},
+			"replaceAllStyles": true,
+		})
+	})
+
+	testacc.Run(t,
+		// terraform manages the default style only
+		resource.TestStep{
+			Config: s.Block(`
+				project_id = "` + projectID + `"
+				data = jsonencode({
+					styles = {
+						light = {}
+						dark = {}
+					}
+				})
+			`),
+			Check: s.Check(map[string]any{
+				"id.==": "project_id",
+				"data":  testacc.AttributeIsSet,
+			}),
+		},
+		// a style appears outside terraform, the way the console creates one, and then the managed
+		// data changes so an import actually runs
+		resource.TestStep{
+			PreConfig: func() {
+				testacc.OutOfBandPost(t, projectID, "/v2/mgmt/theme/import", map[string]any{
+					"theme": map[string]any{"styles": unmanaged},
+				})
+			},
+			Config: s.Block(`
+				project_id = "` + projectID + `"
+				data = jsonencode({
+					styles = {
+						light = {
+							designTokens = {}
+						}
+						dark = {}
+					}
+				})
+			`),
+			Check: func(*terraform.State) error {
+				theme := testacc.OutOfBandPostData(t, projectID, "/v2/mgmt/theme/export", map[string]any{})
+				inner, ok := theme["theme"].(map[string]any)
+				require.True(t, ok, "exported theme has no theme object")
+				styles, ok := inner["styles"].(map[string]any)
+				require.True(t, ok, "exported theme has no styles object")
+				for key := range unmanaged {
+					require.Contains(t, styles, key, "an apply deleted a style Terraform does not manage")
+				}
+				require.Contains(t, styles, "light", "an apply deleted the managed style")
+				return nil
+			},
+		},
+		// the surviving unmanaged style does not turn into a permanent diff
+		resource.TestStep{
+			Config: s.Block(`
+				project_id = "` + projectID + `"
+				data = jsonencode({
+					styles = {
+						light = {
+							designTokens = {}
+						}
+						dark = {}
+					}
+				})
+			`),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
 	)
 }

--- a/internal/models/styles/styles_test.go
+++ b/internal/models/styles/styles_test.go
@@ -77,9 +77,13 @@ func TestStylesKeepsUnmanagedStyles(t *testing.T) {
 		if projectID == "" {
 			return
 		}
-		testacc.OutOfBandPost(t, projectID, "/v2/mgmt/theme/import", map[string]any{
-			"theme":            map[string]any{"styles": map[string]any{"light": map[string]any{}, "dark": map[string]any{}}},
-			"replaceAllStyles": true,
+		// /v2/mgmt/theme/import upserts and never deletes, so it cannot undo what this test
+		// created. The deprecated /v1 endpoint still replaces the whole theme, which is what a
+		// reset needs - it takes the theme in its cssTemplate shape rather than as styles.
+		testacc.OutOfBandPost(t, projectID, "/v1/mgmt/theme/import", map[string]any{
+			"theme": map[string]any{
+				"cssTemplate": map[string]any{"light": map[string]any{}, "dark": map[string]any{}},
+			},
 		})
 	})
 

--- a/tools/testacc/helpers.go
+++ b/tools/testacc/helpers.go
@@ -32,6 +32,17 @@ func FixtureJSON(t *testing.T, path string, replacements ...string) string {
 	return q
 }
 
+// Reads an entity through the management API, bypassing Terraform, to assert on state that the
+// provider does not keep - e.g. a document whose configured value is preserved on read.
+func OutOfBandPostData(t *testing.T, projectID, path string, body map[string]any) map[string]any {
+	base := os.Getenv("DESCOPE_BASE_URL")
+	require.NotEmpty(t, base, "The DESCOPE_BASE_URL environment variable must be set for out-of-band requests")
+	client := infra.NewClient("testacc", os.Getenv("DESCOPE_MANAGEMENT_KEY"), base)
+	data, err := client.PostData(context.Background(), projectID, path, body)
+	require.NoError(t, err, "Out-of-band POST request to %s failed", path)
+	return data
+}
+
 // Removes or modifies an entity through the management API, bypassing Terraform, to simulate out-of-band changes.
 func OutOfBandPost(t *testing.T, projectID, path string, body map[string]any) {
 	base := os.Getenv("DESCOPE_BASE_URL")


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/12809

Backend fix: https://github.com/descope/backend/pull/2564

## Description
- `descope_styles` writes through `POST /v2/mgmt/theme/import`, which used to replace the whole theme — so every apply deleted the styles the `data` did not carry, including styles created in the console that Terraform cannot see. That is how the reporting customer lost styles. That endpoint now upserts, so **no provider code change is needed**.
- Verified against a running stack: a partial import carrying one style — byte-identical to what this resource sends — left all six styles in the project intact.
- What the provider does need is to **say so**, because the flip side is that removing a style from `data` no longer removes it from the project. `data`'s description now states both halves.
- `TestStylesKeepsUnmanagedStyles`: a style created out of band (as the console does) survives an apply that changes the managed `data`, and a following `PlanOnly` step asserts it does not become a permanent diff. `testacc.OutOfBandPostData` comes along as a reading counterpart to the existing write-only helper — state alone cannot show what is on the server here, precisely because `read` preserves the configured document (`jsonattr.SkipIfAlreadySet`).
- The test resets the project through the deprecated `/v1/mgmt/theme/import`, which still replaces the whole theme. Nothing on the v2 surface can delete a style any more, so v2 cannot undo what the test creates.

## Notes for the reviewer
- **Sequencing:** the acceptance test only passes against a backend carrying the new `ImportStyles` behaviour. It is behind `TF_ACC`, so unit CI is unaffected, but do not land ahead of descope/backend#2564.
- **Hand-edited docs:** both generators failed in my environment — `tfplugindocs` could not fetch Terraform (expired PGP key in v0.19.4) and `terragen` wants `DESCOPE_TEMPLATES_PATH`. `docs/resources/styles.md` and `docs/raw/styles/styles.md` were written to match `internal/docs/docs.go` exactly, so a regen should be a no-op — please confirm with a working toolchain.
- **Still open:** whether `descope_styles` should stay non-authoritative. A per-style `descope_style` resource on the backend's new `ImportStyles`/`ExportStyle` would let Terraform manage exactly the styles it declares, which resolves the tension properly. Not attempted here.

## Must
- [x] Acceptance Tests
- [x] Schema Compatibility — no schema change, description text only
- [x] Documentation Updates
